### PR TITLE
feat(EM-228): Manager gán Thư ký (Secretary) cho sự kiện

### DIFF
--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -21,6 +21,7 @@ import 'package:event_management/features/event/presentation/bloc/edit_event/edi
 import 'package:event_management/features/event/presentation/bloc/event_detail/event_detail_bloc.dart';
 import 'package:event_management/features/event/presentation/bloc/event_list_bloc.dart';
 import 'package:event_management/features/event/presentation/bloc/event_management/event_management_bloc.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_bloc.dart';
 import 'package:event_management/features/unit/data/datasource/unit_api_client.dart';
 import 'package:event_management/features/unit/data/repository/unit_repository_impl.dart';
 import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
@@ -69,6 +70,10 @@ Future<void> init() async {
     )
     ..registerFactory(() => EventDetailBloc(eventRepository: sl()))
     ..registerFactory(() => EventManagementBloc(eventRepository: sl()))
+    ..registerFactory(
+      () =>
+          SecretaryManagementBloc(eventRepository: sl(), adminRepository: sl()),
+    )
     // Admin Bloc
     ..registerFactory(() => UserManagementBloc(adminRepository: sl()))
     // Dio instances - Main Dio for general use (has auth interceptor)

--- a/lib/features/event/data/datasources/event_api_client.dart
+++ b/lib/features/event/data/datasources/event_api_client.dart
@@ -4,6 +4,7 @@ import 'package:event_management/features/event/data/models/create_event_dto.dar
 import 'package:event_management/features/event/data/models/event.dart';
 import 'package:event_management/features/event/data/models/event_detail_response.dart';
 import 'package:event_management/features/event/data/models/event_dto.dart';
+import 'package:event_management/features/event/data/models/event_manager_dto.dart';
 import 'package:event_management/features/event/data/models/event_page_with_counters_response_dto.dart';
 import 'package:event_management/features/event/data/models/image_upload_response.dart';
 import 'package:event_management/features/event/data/models/import_job_response.dart';
@@ -84,4 +85,9 @@ abstract class EventApiClient {
 
   @POST('/attendants/check-in/{eventToken}')
   Future<Attendant> checkInEvent(@Path('eventToken') String eventToken);
+
+  @GET('/event-manager/event-managers')
+  Future<List<EventManagerDto>> getEventManagersByEventId({
+    @Query('eventId') required int eventId,
+  });
 }

--- a/lib/features/event/data/datasources/event_api_client.g.dart
+++ b/lib/features/event/data/datasources/event_api_client.g.dart
@@ -423,6 +423,39 @@ class _EventApiClient implements EventApiClient {
     return _value;
   }
 
+  @override
+  Future<List<EventManagerDto>> getEventManagersByEventId({
+    required int eventId,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'eventId': eventId};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<EventManagerDto>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/event-manager/event-managers',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<EventManagerDto> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) => EventManagerDto.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/event/data/models/event_manager_dto.dart
+++ b/lib/features/event/data/models/event_manager_dto.dart
@@ -1,0 +1,31 @@
+import 'package:event_management/features/admin/data/models/event_management.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'event_manager_dto.g.dart';
+
+/// DTO for EventManager from backend API response.
+/// Matches the backend EventManagerDto structure.
+@JsonSerializable(createToJson: false)
+class EventManagerDto {
+  const EventManagerDto({
+    required this.eventId,
+    required this.userId,
+    required this.roleType,
+    this.assignedBy,
+  });
+
+  factory EventManagerDto.fromJson(Map<String, dynamic> json) =>
+      _$EventManagerDtoFromJson(json);
+
+  @JsonKey(name: 'event_id')
+  final int eventId;
+
+  @JsonKey(name: 'user_id')
+  final int userId;
+
+  @JsonKey(name: 'role_type')
+  final EventManagement roleType;
+
+  @JsonKey(name: 'assigned_by')
+  final int? assignedBy;
+}

--- a/lib/features/event/data/models/event_manager_dto.g.dart
+++ b/lib/features/event/data/models/event_manager_dto.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'event_manager_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+EventManagerDto _$EventManagerDtoFromJson(Map<String, dynamic> json) =>
+    EventManagerDto(
+      eventId: (json['event_id'] as num).toInt(),
+      userId: (json['user_id'] as num).toInt(),
+      roleType: $enumDecode(_$EventManagementEnumMap, json['role_type']),
+      assignedBy: (json['assigned_by'] as num?)?.toInt(),
+    );
+
+const _$EventManagementEnumMap = {
+  EventManagement.manage: 'MANAGE',
+  EventManagement.staff: 'STAFF',
+};

--- a/lib/features/event/data/models/event_manager_info.dart
+++ b/lib/features/event/data/models/event_manager_info.dart
@@ -1,0 +1,82 @@
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/admin/data/models/event_management.dart';
+import 'package:event_management/features/event/data/models/event_manager_dto.dart';
+
+/// Model representing an event manager with user information.
+/// This is used for displaying managers/staff assigned to an event.
+class EventManagerInfo extends Equatable {
+  const EventManagerInfo({
+    required this.eventId,
+    required this.userId,
+    required this.roleType,
+    this.userName,
+    this.userEmail,
+    this.assignedBy,
+  });
+
+  /// Creates EventManagerInfo from DTO and user information.
+  factory EventManagerInfo.fromDto({
+    required EventManagerDto dto,
+    String? userName,
+    String? userEmail,
+  }) {
+    return EventManagerInfo(
+      eventId: dto.eventId,
+      userId: dto.userId,
+      roleType: dto.roleType,
+      assignedBy: dto.assignedBy,
+      userName: userName,
+      userEmail: userEmail,
+    );
+  }
+
+  final int eventId;
+  final int userId;
+  final EventManagement roleType;
+  final String? userName;
+  final String? userEmail;
+  final int? assignedBy;
+
+  /// Creates a copy with updated values.
+  EventManagerInfo copyWith({
+    int? eventId,
+    int? userId,
+    EventManagement? roleType,
+    String? userName,
+    String? userEmail,
+    int? assignedBy,
+  }) {
+    return EventManagerInfo(
+      eventId: eventId ?? this.eventId,
+      userId: userId ?? this.userId,
+      roleType: roleType ?? this.roleType,
+      userName: userName ?? this.userName,
+      userEmail: userEmail ?? this.userEmail,
+      assignedBy: assignedBy ?? this.assignedBy,
+    );
+  }
+
+  bool hasAtLeastRole(EventManagement requiredRole) {
+    if (requiredRole == EventManagement.staff) {
+      return true;
+    }
+    if (requiredRole == EventManagement.manage) {
+      return roleType == EventManagement.manage;
+    }
+    return false;
+  }
+
+  bool get isStaff => roleType == EventManagement.staff;
+
+  bool get isManager => roleType == EventManagement.manage;
+
+  @override
+  List<Object?> get props => [
+    eventId,
+    userId,
+    userName,
+    userEmail,
+    roleType,
+    assignedBy,
+  ];
+}

--- a/lib/features/event/data/repositories/event_repository_impl.dart
+++ b/lib/features/event/data/repositories/event_repository_impl.dart
@@ -8,6 +8,7 @@ import 'package:event_management/features/event/data/models/create_event_dto.dar
 import 'package:event_management/features/event/data/models/event.dart';
 import 'package:event_management/features/event/data/models/event_detail_response.dart';
 import 'package:event_management/features/event/data/models/event_dto.dart';
+import 'package:event_management/features/event/data/models/event_manager_info.dart';
 import 'package:event_management/features/event/data/models/event_status.dart';
 import 'package:event_management/features/event/data/models/import_job_response.dart';
 import 'package:event_management/features/event/data/models/import_participants_response.dart';
@@ -160,20 +161,46 @@ class EventRepositoryImpl implements EventRepository {
   @override
   Future<Event> uploadBannerFromXFile(int eventId, XFile bannerFile) async {
     try {
+      if (kDebugMode) {
+        debugPrint(
+          'EventRepository: Uploading banner from XFile: ${bannerFile.path}',
+        );
+        debugPrint('EventRepository: File name: ${bannerFile.name}');
+      }
+
       final bytes = await bannerFile.readAsBytes();
+
+      if (kDebugMode) {
+        debugPrint('EventRepository: Read ${bytes.length} bytes from file');
+      }
 
       final fileName = bannerFile.name;
 
       final multipartFile = MultipartFile.fromBytes(bytes, filename: fileName);
 
+      if (kDebugMode) {
+        debugPrint(
+          'EventRepository: Calling uploadBanner API for event $eventId',
+        );
+      }
+
       return await _eventApiClient.uploadBanner(eventId, multipartFile);
     } on DioException catch (e) {
+      if (kDebugMode) {
+        debugPrint('EventRepository: DioException during banner upload: $e');
+        debugPrint('EventRepository: Response: ${e.response?.data}');
+      }
       if (e.response?.data != null && e.response!.data is Map) {
         final errorMessage = e.response!.data['message'] as String?;
         throw Exception(errorMessage ?? 'Không thể tải lên banner.');
       }
       throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
     } catch (e) {
+      if (kDebugMode) {
+        debugPrint('EventRepository: Error during banner upload: $e');
+        debugPrint('EventRepository: Error type: ${e.runtimeType}');
+      }
+      if (e is Exception) rethrow;
       throw Exception('Đã xảy ra lỗi không xác định: $e');
     }
   }
@@ -456,6 +483,31 @@ class EventRepositoryImpl implements EventRepository {
     } catch (e) {
       if (e is Exception) rethrow;
       throw Exception('Lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<List<EventManagerInfo>> getEventManagers(int eventId) async {
+    try {
+      final dtos = await _eventApiClient.getEventManagersByEventId(
+        eventId: eventId,
+      );
+
+      // Convert DTOs to EventManagerInfo
+      // Note: userName and userEmail are not provided by backend,
+      // they will be null and should be enriched separately if needed
+      return dtos.map((dto) => EventManagerInfo.fromDto(dto: dto)).toList();
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(
+          errorMessage ?? 'Không thể tải danh sách quản lý sự kiện.',
+        );
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      if (e is Exception) rethrow;
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
     }
   }
 }

--- a/lib/features/event/domain/repositories/event_repository.dart
+++ b/lib/features/event/domain/repositories/event_repository.dart
@@ -6,6 +6,7 @@ import 'package:event_management/features/event/data/models/event.dart';
 import 'package:event_management/features/event/data/models/event_counters.dart';
 import 'package:event_management/features/event/data/models/event_detail_response.dart';
 import 'package:event_management/features/event/data/models/event_dto.dart';
+import 'package:event_management/features/event/data/models/event_manager_info.dart';
 import 'package:event_management/features/event/data/models/event_status.dart';
 import 'package:event_management/features/event/data/models/import_job_response.dart';
 import 'package:event_management/features/event/data/models/import_participants_response.dart';
@@ -60,6 +61,8 @@ abstract class EventRepository {
   });
 
   Future<Uint8List> getQrCheck(int eventId);
+
+  Future<List<EventManagerInfo>> getEventManagers(int eventId);
 }
 
 class EventListResult {

--- a/lib/features/event/presentation/bloc/secretary_management/secretary_management_bloc.dart
+++ b/lib/features/event/presentation/bloc/secretary_management/secretary_management_bloc.dart
@@ -1,0 +1,206 @@
+import 'package:bloc/bloc.dart';
+import 'package:event_management/features/admin/data/models/event_management.dart';
+import 'package:event_management/features/admin/domain/repositories/admin_repository.dart';
+import 'package:event_management/features/event/domain/repositories/event_repository.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_event.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_state.dart';
+import 'package:flutter/foundation.dart';
+import 'package:injectable/injectable.dart';
+
+/// BLoC for managing secretaries (staff) for events.
+@injectable
+class SecretaryManagementBloc
+    extends Bloc<SecretaryManagementEvent, SecretaryManagementState> {
+  SecretaryManagementBloc({
+    required EventRepository eventRepository,
+    required AdminRepository adminRepository,
+  }) : _eventRepository = eventRepository,
+       _adminRepository = adminRepository,
+       super(SecretaryManagementInitial()) {
+    on<SecretaryManagementFetchEventManagers>(_onFetchEventManagers);
+    on<SecretaryManagementAssignSecretary>(_onAssignSecretary);
+    on<SecretaryManagementRemoveSecretary>(_onRemoveSecretary);
+    on<SecretaryManagementRefresh>(_onRefresh);
+  }
+
+  final EventRepository _eventRepository;
+  final AdminRepository _adminRepository;
+
+  Future<void> _onFetchEventManagers(
+    SecretaryManagementFetchEventManagers event,
+    Emitter<SecretaryManagementState> emit,
+  ) async {
+    emit(const SecretaryManagementLoading());
+
+    try {
+      // Fetch event managers from API
+      final eventManagers = await _eventRepository.getEventManagers(
+        event.eventId,
+      );
+
+      // Emit success state with event managers
+      emit(SecretaryManagementSuccess(eventManagers: eventManagers));
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('Error fetching event managers: $e');
+      }
+      emit(
+        SecretaryManagementError(
+          error: e.toString().replaceFirst('Exception: ', ''),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onAssignSecretary(
+    SecretaryManagementAssignSecretary event,
+    Emitter<SecretaryManagementState> emit,
+  ) async {
+    final currentState = state;
+
+    // Optimistic update: show loading while assigning
+    if (currentState is SecretaryManagementSuccess) {
+      emit(const SecretaryManagementLoading(isRefreshing: true));
+    } else {
+      emit(const SecretaryManagementLoading());
+    }
+
+    try {
+      await _adminRepository.assignEventManager(
+        eventId: event.eventId,
+        userId: event.userId,
+        roleType: EventManagement.staff,
+        assignedBy: event.assignedBy,
+      );
+
+      // Fetch updated list after successful assignment
+      final eventManagers = await _eventRepository.getEventManagers(
+        event.eventId,
+      );
+      emit(
+        const SecretaryManagementAssignSuccess(
+          message: 'Đã thêm thư ký thành công',
+        ),
+      );
+      // Emit success state with updated list after a short delay
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      emit(SecretaryManagementSuccess(eventManagers: eventManagers));
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('Error assigning secretary: $e');
+      }
+
+      // Restore previous state on error
+      if (currentState is SecretaryManagementSuccess) {
+        emit(currentState);
+      }
+
+      emit(
+        SecretaryManagementError(
+          error: e.toString().replaceFirst('Exception: ', ''),
+        ),
+      );
+
+      // Restore success state after showing error
+      if (currentState is SecretaryManagementSuccess) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+        emit(currentState);
+      }
+    }
+  }
+
+  Future<void> _onRemoveSecretary(
+    SecretaryManagementRemoveSecretary event,
+    Emitter<SecretaryManagementState> emit,
+  ) async {
+    final currentState = state;
+
+    // Optimistic update: show loading while removing
+    if (currentState is SecretaryManagementSuccess) {
+      emit(const SecretaryManagementLoading(isRefreshing: true));
+    } else {
+      emit(const SecretaryManagementLoading());
+    }
+
+    try {
+      await _adminRepository.removeEventManager(
+        eventId: event.eventId,
+        userId: event.userId,
+        roleType: EventManagement.staff,
+      );
+
+      // Fetch updated list after successful removal
+      final eventManagers = await _eventRepository.getEventManagers(
+        event.eventId,
+      );
+      emit(
+        const SecretaryManagementRemoveSuccess(
+          message: 'Đã xóa thư ký thành công',
+        ),
+      );
+      // Emit success state with updated list after a short delay
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      emit(SecretaryManagementSuccess(eventManagers: eventManagers));
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('Error removing secretary: $e');
+      }
+
+      // Restore previous state on error
+      if (currentState is SecretaryManagementSuccess) {
+        emit(currentState);
+      }
+
+      emit(
+        SecretaryManagementError(
+          error: e.toString().replaceFirst('Exception: ', ''),
+        ),
+      );
+
+      // Restore success state after showing error
+      if (currentState is SecretaryManagementSuccess) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+        emit(currentState);
+      }
+    }
+  }
+
+  Future<void> _onRefresh(
+    SecretaryManagementRefresh event,
+    Emitter<SecretaryManagementState> emit,
+  ) async {
+    final currentState = state;
+
+    // Keep current state if it's a success state while loading
+    if (currentState is SecretaryManagementSuccess) {
+      emit(const SecretaryManagementLoading(isRefreshing: true));
+    } else {
+      emit(const SecretaryManagementLoading());
+    }
+
+    try {
+      // Fetch event managers from API
+      final eventManagers = await _eventRepository.getEventManagers(
+        event.eventId,
+      );
+
+      // Emit success state with event managers
+      emit(SecretaryManagementSuccess(eventManagers: eventManagers));
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('Error refreshing event managers: $e');
+      }
+
+      // Restore previous state on error
+      if (currentState is SecretaryManagementSuccess) {
+        emit(currentState);
+      } else {
+        emit(
+          SecretaryManagementError(
+            error: e.toString().replaceFirst('Exception: ', ''),
+          ),
+        );
+      }
+    }
+  }
+}

--- a/lib/features/event/presentation/bloc/secretary_management/secretary_management_event.dart
+++ b/lib/features/event/presentation/bloc/secretary_management/secretary_management_event.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+
+/// Events for Secretary Management BLoC.
+abstract class SecretaryManagementEvent extends Equatable {
+  const SecretaryManagementEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event to fetch event managers (including secretaries/staff).
+class SecretaryManagementFetchEventManagers extends SecretaryManagementEvent {
+  const SecretaryManagementFetchEventManagers({required this.eventId});
+
+  final int eventId;
+
+  @override
+  List<Object?> get props => [eventId];
+}
+
+/// Event to assign a secretary (STAFF role) to an event.
+class SecretaryManagementAssignSecretary extends SecretaryManagementEvent {
+  const SecretaryManagementAssignSecretary({
+    required this.eventId,
+    required this.userId,
+    required this.assignedBy,
+  });
+
+  final int eventId;
+  final int userId;
+  final int assignedBy;
+
+  @override
+  List<Object?> get props => [eventId, userId, assignedBy];
+}
+
+/// Event to remove a secretary from an event.
+class SecretaryManagementRemoveSecretary extends SecretaryManagementEvent {
+  const SecretaryManagementRemoveSecretary({
+    required this.eventId,
+    required this.userId,
+  });
+
+  final int eventId;
+  final int userId;
+
+  @override
+  List<Object?> get props => [eventId, userId];
+}
+
+class SecretaryManagementRefresh extends SecretaryManagementEvent {
+  const SecretaryManagementRefresh({required this.eventId});
+
+  final int eventId;
+
+  @override
+  List<Object?> get props => [eventId];
+}

--- a/lib/features/event/presentation/bloc/secretary_management/secretary_management_state.dart
+++ b/lib/features/event/presentation/bloc/secretary_management/secretary_management_state.dart
@@ -1,0 +1,85 @@
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/event/data/models/event_manager_info.dart';
+
+/// States for Secretary Management BLoC.
+abstract class SecretaryManagementState extends Equatable {
+  const SecretaryManagementState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Initial state.
+class SecretaryManagementInitial extends SecretaryManagementState {}
+
+/// Loading state when fetching or performing operations.
+class SecretaryManagementLoading extends SecretaryManagementState {
+  const SecretaryManagementLoading({this.isRefreshing = false});
+
+  final bool isRefreshing;
+
+  @override
+  List<Object?> get props => [isRefreshing];
+}
+
+/// Success state with list of event managers.
+class SecretaryManagementSuccess extends SecretaryManagementState {
+  const SecretaryManagementSuccess({
+    required this.eventManagers,
+    this.staffOnly = false,
+  });
+
+  final List<EventManagerInfo> eventManagers;
+  final bool staffOnly;
+
+  /// Gets only staff members (secretaries).
+  List<EventManagerInfo> get staffMembers =>
+      eventManagers.where((m) => m.isStaff).toList();
+
+  /// Gets only managers.
+  List<EventManagerInfo> get managers =>
+      eventManagers.where((m) => m.isManager).toList();
+
+  @override
+  List<Object?> get props => [eventManagers, staffOnly];
+
+  SecretaryManagementSuccess copyWith({
+    List<EventManagerInfo>? eventManagers,
+    bool? staffOnly,
+  }) {
+    return SecretaryManagementSuccess(
+      eventManagers: eventManagers ?? this.eventManagers,
+      staffOnly: staffOnly ?? this.staffOnly,
+    );
+  }
+}
+
+/// Error state.
+class SecretaryManagementError extends SecretaryManagementState {
+  const SecretaryManagementError({required this.error});
+
+  final String error;
+
+  @override
+  List<Object> get props => [error];
+}
+
+/// Success state for assign operation.
+class SecretaryManagementAssignSuccess extends SecretaryManagementState {
+  const SecretaryManagementAssignSuccess({required this.message});
+
+  final String message;
+
+  @override
+  List<Object> get props => [message];
+}
+
+/// Success state for remove operation.
+class SecretaryManagementRemoveSuccess extends SecretaryManagementState {
+  const SecretaryManagementRemoveSuccess({required this.message});
+
+  final String message;
+
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/features/event/presentation/widgets/event_management/add_secretary_dialog.dart
+++ b/lib/features/event/presentation/widgets/event_management/add_secretary_dialog.dart
@@ -1,0 +1,272 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/features/auth/domain/repositories/auth_repository.dart';
+import 'package:event_management/features/event/data/models/participant.dart';
+import 'package:event_management/features/event/domain/repositories/event_repository.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_bloc.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_event.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Dialog for adding a secretary (staff) to an event.
+class AddSecretaryDialog extends StatefulWidget {
+  const AddSecretaryDialog({
+    required this.eventId,
+    required this.participants,
+    required this.onSecretaryAdded,
+    super.key,
+  });
+
+  final int eventId;
+  final List<ParticipantInfo> participants;
+  final VoidCallback onSecretaryAdded;
+
+  @override
+  State<AddSecretaryDialog> createState() => _AddSecretaryDialogState();
+}
+
+class _AddSecretaryDialogState extends State<AddSecretaryDialog> {
+  final TextEditingController _searchController = TextEditingController();
+  List<ParticipantInfo> _availableParticipants = [];
+  List<ParticipantInfo> _filteredParticipants = [];
+  bool _isLoadingParticipants = true;
+  bool _isAssigning = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAvailableParticipants();
+    _searchController.addListener(_onSearchChanged);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadAvailableParticipants() async {
+    setState(() {
+      _isLoadingParticipants = true;
+    });
+
+    try {
+      final eventRepository = di.sl<EventRepository>();
+
+      // Get existing managers/staff to filter out
+      final existingManagers = await eventRepository.getEventManagers(
+        widget.eventId,
+      );
+      final existingUserIds = existingManagers.map((m) => m.userId).toSet();
+
+      // Filter participants: only those who are not already managers/staff
+      setState(() {
+        _availableParticipants = widget.participants
+            .where(
+              (participant) => !existingUserIds.contains(participant.userId),
+            )
+            .toList();
+        _filteredParticipants = _availableParticipants;
+        _isLoadingParticipants = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoadingParticipants = false;
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Không thể tải danh sách người tham gia: $e'),
+            backgroundColor: AppColors.red500,
+          ),
+        );
+      }
+    }
+  }
+
+  void _onSearchChanged() {
+    final query = _searchController.text.toLowerCase().trim();
+    setState(() {
+      if (query.isEmpty) {
+        _filteredParticipants = _availableParticipants;
+      } else {
+        _filteredParticipants = _availableParticipants.where((participant) {
+          final name = participant.userName.toLowerCase();
+          final email = participant.userEmail?.toLowerCase() ?? '';
+          return name.contains(query) || email.contains(query);
+        }).toList();
+      }
+    });
+  }
+
+  Future<void> _assignSecretary(ParticipantInfo participant) async {
+    setState(() {
+      _isAssigning = true;
+    });
+
+    try {
+      final authRepository = di.sl<AuthRepository>();
+      final currentUser = await authRepository.getAuthUser();
+      final currentUserId = currentUser.id;
+
+      // Add to BLoC
+      if (mounted) {
+        context.read<SecretaryManagementBloc>().add(
+          SecretaryManagementAssignSecretary(
+            eventId: widget.eventId,
+            userId: participant.userId,
+            assignedBy: currentUserId,
+          ),
+        );
+      }
+
+      // Call callback
+      widget.onSecretaryAdded();
+
+      // Close dialog after a short delay
+      if (mounted) {
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+        if (mounted) {
+          Navigator.of(context).pop();
+        }
+      }
+    } catch (e) {
+      setState(() {
+        _isAssigning = false;
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Không thể thêm thư ký: $e'),
+            backgroundColor: AppColors.red500,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 500, maxHeight: 600),
+        padding: const EdgeInsets.all(AppSpacing.spaceLG),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Thêm Thư ký', style: AppTextStyles.heading3),
+                IconButton(
+                  icon: const Icon(Icons.close_rounded),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                hintText: 'Tìm kiếm theo tên hoặc email...',
+                hintStyle: AppTextStyles.bodyMedium,
+                prefixIcon: const Icon(
+                  Icons.search_rounded,
+                  color: AppColors.coolGray500,
+                ),
+                suffixIcon: _searchController.text.isNotEmpty
+                    ? IconButton(
+                        icon: const Icon(Icons.clear_rounded),
+                        onPressed: _searchController.clear,
+                      )
+                    : null,
+                filled: true,
+                fillColor: AppColors.coolGray50,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            if (_isLoadingParticipants)
+              const Expanded(child: Center(child: CircularProgressIndicator()))
+            else if (_filteredParticipants.isEmpty)
+              Expanded(
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(
+                        Icons.search_off_rounded,
+                        size: 48,
+                        color: AppColors.coolGray500,
+                      ),
+                      const SizedBox(height: AppSpacing.spaceMD),
+                      Text(
+                        _availableParticipants.isEmpty
+                            ? 'Tất cả người tham gia đã được gán làm thư ký'
+                            : 'Không tìm thấy người tham gia',
+                        style: AppTextStyles.bodyMedium,
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              Expanded(
+                child: ListView.separated(
+                  itemCount: _filteredParticipants.length,
+                  separatorBuilder: (context, index) =>
+                      const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final participant = _filteredParticipants[index];
+                    final name = participant.userName;
+                    final email = participant.userEmail ?? 'Chưa có email';
+                    final initials = name.isNotEmpty
+                        ? name[0].toUpperCase()
+                        : 'U';
+                    return ListTile(
+                      leading: CircleAvatar(
+                        backgroundColor: AppColors.vkuBlue.withOpacity(0.1),
+                        child: Text(
+                          initials,
+                          style: AppTextStyles.heading5.copyWith(
+                            color: AppColors.vkuBlue,
+                          ),
+                        ),
+                      ),
+                      title: Text(name, style: AppTextStyles.heading5),
+                      subtitle: Text(email, style: AppTextStyles.bodySmall),
+                      trailing: _isAssigning
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : IconButton(
+                              icon: const Icon(Icons.add_circle_rounded),
+                              color: AppColors.vkuBlue,
+                              onPressed: () => _assignSecretary(participant),
+                              tooltip: 'Thêm làm thư ký',
+                            ),
+                      onTap: _isAssigning
+                          ? null
+                          : () => _assignSecretary(participant),
+                    );
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/event/presentation/widgets/event_management/secretary_management_section.dart
+++ b/lib/features/event/presentation/widgets/event_management/secretary_management_section.dart
@@ -1,32 +1,105 @@
 import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
 import 'package:event_management/core/config/app_text_styles.dart';
-import 'package:event_management/features/event/data/models/secretary.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/features/event/data/models/event_manager_info.dart';
+import 'package:event_management/features/event/data/models/participant.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_bloc.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_event.dart';
+import 'package:event_management/features/event/presentation/bloc/secretary_management/secretary_management_state.dart';
+import 'package:event_management/features/event/presentation/widgets/event_management/add_secretary_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
-class SecretaryManagementSection extends StatelessWidget {
+class SecretaryManagementSection extends StatefulWidget {
   const SecretaryManagementSection({
-    required this.secretaries,
     required this.eventId,
+    required this.participants,
     super.key,
   });
 
-  final List<SecretaryInfo> secretaries;
   final int eventId;
+  final List<ParticipantInfo> participants;
+
+  @override
+  State<SecretaryManagementSection> createState() =>
+      _SecretaryManagementSectionState();
+}
+
+class _SecretaryManagementSectionState
+    extends State<SecretaryManagementSection> {
+  /// Enriches EventManagerInfo with user information from participants list.
+  List<EventManagerInfo> _enrichManagersWithParticipants(
+    List<EventManagerInfo> managers,
+  ) {
+    // Create a map of userId -> ParticipantInfo for quick lookup
+    final participantMap = {
+      for (final participant in widget.participants)
+        participant.userId: participant,
+    };
+
+    // Enrich each manager with participant information
+    return managers.map((manager) {
+      final participant = participantMap[manager.userId];
+      if (participant != null) {
+        // Always enrich with participant info if found
+        return manager.copyWith(
+          userName: participant.userName,
+          userEmail: participant.userEmail,
+        );
+      }
+      return manager;
+    }).toList();
+  }
 
   void _showAddSecretaryDialog(BuildContext context) {
-    // TODO: Implement add secretary dialog (Chức năng 5)
+    // Get the bloc instance before opening dialog
+    final bloc = context.read<SecretaryManagementBloc>();
+
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => BlocProvider.value(
+        value: bloc,
+        child: AddSecretaryDialog(
+          eventId: widget.eventId,
+          participants: widget.participants,
+          onSecretaryAdded: () {
+            // Refresh the list after adding
+            bloc.add(SecretaryManagementRefresh(eventId: widget.eventId));
+          },
+        ),
+      ),
+    );
+  }
+
+  void _showRemoveConfirmation(
+    BuildContext context,
+    EventManagerInfo secretary,
+  ) {
     showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Thêm thư ký'),
-        content: const Text(
-          'Chức năng tìm kiếm và thêm thư ký đang được phát triển',
+        title: const Text('Xác nhận xóa'),
+        content: Text(
+          'Bạn có chắc chắn muốn xóa thư ký "${secretary.userName}" khỏi sự kiện này?',
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Đóng'),
+            child: const Text('Hủy'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              context.read<SecretaryManagementBloc>().add(
+                SecretaryManagementRemoveSecretary(
+                  eventId: widget.eventId,
+                  userId: secretary.userId,
+                ),
+              );
+            },
+            style: TextButton.styleFrom(foregroundColor: AppColors.red500),
+            child: const Text('Xóa'),
           ),
         ],
       ),
@@ -35,85 +108,174 @@ class SecretaryManagementSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.spaceLG),
-      decoration: BoxDecoration(
-        color: AppColors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.coolGray900.withOpacity(0.08),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('Quản lý Thư ký', style: AppTextStyles.heading3),
-              IconButton(
-                icon: const Icon(Icons.add_moderator_rounded),
-                onPressed: () => _showAddSecretaryDialog(context),
-                tooltip: 'Thêm thư ký',
-                color: AppColors.vkuBlue,
+    return BlocProvider(
+      create: (context) => di.sl<SecretaryManagementBloc>()
+        ..add(SecretaryManagementFetchEventManagers(eventId: widget.eventId)),
+      child: BlocConsumer<SecretaryManagementBloc, SecretaryManagementState>(
+        listener: (context, state) {
+          if (state is SecretaryManagementError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.error),
+                backgroundColor: AppColors.red500,
               ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.spaceMD),
-          if (secretaries.isEmpty)
-            Padding(
-              padding: const EdgeInsets.all(AppSpacing.spaceLG),
-              child: Center(
-                child: Column(
+            );
+          } else if (state is SecretaryManagementAssignSuccess) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.green500,
+              ),
+            );
+          } else if (state is SecretaryManagementRemoveSuccess) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.green500,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          return Container(
+            padding: const EdgeInsets.all(AppSpacing.spaceLG),
+            decoration: BoxDecoration(
+              color: AppColors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.coolGray900.withOpacity(0.08),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    const Icon(
-                      Icons.people_outline_rounded,
-                      size: 48,
-                      color: AppColors.coolGray500,
-                    ),
-                    const SizedBox(height: AppSpacing.spaceMD),
-                    Text('Chưa có thư ký nào', style: AppTextStyles.bodyMedium),
-                    const SizedBox(height: AppSpacing.spaceXS),
-                    Text(
-                      'Nhấn nút + để thêm thư ký',
-                      style: AppTextStyles.bodySmall,
+                    Text('Quản lý Thư ký', style: AppTextStyles.heading3),
+                    IconButton(
+                      icon: const Icon(Icons.add_moderator_rounded),
+                      onPressed: state is SecretaryManagementLoading
+                          ? null
+                          : () => _showAddSecretaryDialog(context),
+                      tooltip: 'Thêm thư ký',
+                      color: AppColors.vkuBlue,
                     ),
                   ],
                 ),
-              ),
-            )
-          else
-            ListView.separated(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: secretaries.length,
-              separatorBuilder: (context, index) => const Divider(height: 1),
-              itemBuilder: (context, index) {
-                final secretary = secretaries[index];
-                return _SecretaryListItem(secretary: secretary);
-              },
+                const SizedBox(height: AppSpacing.spaceMD),
+                if (state is SecretaryManagementLoading)
+                  const Padding(
+                    padding: EdgeInsets.all(AppSpacing.spaceLG),
+                    child: Center(child: CircularProgressIndicator()),
+                  )
+                else if (state is SecretaryManagementSuccess)
+                  _buildSecretaryList(
+                    context,
+                    _enrichManagersWithParticipants(state.staffMembers),
+                  )
+                else if (state is SecretaryManagementError)
+                  _buildErrorState(context)
+                else
+                  _buildEmptyState(),
+              ],
             ),
-        ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSecretaryList(
+    BuildContext context,
+    List<EventManagerInfo> secretaries,
+  ) {
+    if (secretaries.isEmpty) {
+      return _buildEmptyState();
+    }
+
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: secretaries.length,
+      separatorBuilder: (context, index) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final secretary = secretaries[index];
+        return _SecretaryListItem(
+          secretary: secretary,
+          onRemove: () => _showRemoveConfirmation(context, secretary),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.spaceLG),
+      child: Center(
+        child: Column(
+          children: [
+            const Icon(
+              Icons.people_outline_rounded,
+              size: 48,
+              color: AppColors.coolGray500,
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            Text('Chưa có thư ký nào', style: AppTextStyles.bodyMedium),
+            const SizedBox(height: AppSpacing.spaceXS),
+            Text('Nhấn nút + để thêm thư ký', style: AppTextStyles.bodySmall),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.spaceLG),
+      child: Center(
+        child: Column(
+          children: [
+            const Icon(
+              Icons.error_outline_rounded,
+              size: 48,
+              color: AppColors.red500,
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            Text('Có lỗi xảy ra', style: AppTextStyles.bodyMedium),
+            const SizedBox(height: AppSpacing.spaceXS),
+            ElevatedButton(
+              onPressed: () {
+                context.read<SecretaryManagementBloc>().add(
+                  SecretaryManagementRefresh(eventId: widget.eventId),
+                );
+              },
+              child: const Text('Thử lại'),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
 class _SecretaryListItem extends StatelessWidget {
-  const _SecretaryListItem({required this.secretary});
+  const _SecretaryListItem({required this.secretary, required this.onRemove});
 
-  final SecretaryInfo secretary;
+  final EventManagerInfo secretary;
+  final VoidCallback onRemove;
 
   String get _initials {
-    final names = secretary.userName.split(' ');
+    final name = secretary.userName ?? 'U';
+    final names = name.split(' ');
     if (names.length >= 2) {
       return '${names[0][0]}${names[names.length - 1][0]}'.toUpperCase();
     }
-    return secretary.userName[0].toUpperCase();
+    return name[0].toUpperCase();
   }
 
   @override
@@ -131,21 +293,18 @@ class _SecretaryListItem extends StatelessWidget {
           style: AppTextStyles.heading5.copyWith(color: AppColors.blue400),
         ),
       ),
-      title: Text(secretary.userName, style: AppTextStyles.heading5),
+      title: Text(
+        secretary.userName ?? 'User #${secretary.userId}',
+        style: AppTextStyles.heading5,
+      ),
       subtitle: secretary.userEmail != null
           ? Text(secretary.userEmail!, style: AppTextStyles.bodySmall)
           : null,
       trailing: IconButton(
         icon: const Icon(Icons.remove_circle_outline_rounded),
         color: AppColors.red500,
-        onPressed: () {
-          // TODO: Implement remove secretary
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Chức năng xóa thư ký đang được phát triển'),
-            ),
-          );
-        },
+        onPressed: onRemove,
+        tooltip: 'Xóa thư ký',
       ),
     );
   }

--- a/lib/features/event/presentation/widgets/event_management/tools_settings_tab.dart
+++ b/lib/features/event/presentation/widgets/event_management/tools_settings_tab.dart
@@ -22,8 +22,8 @@ class ToolsSettingsTab extends StatelessWidget {
 
           // Secretary Management Section
           SecretaryManagementSection(
-            secretaries: eventDetail.secretaries,
             eventId: eventDetail.id,
+            participants: eventDetail.participants,
           ),
         ],
       ),


### PR DESCRIPTION
- Thêm models: EventManagerDto, EventManagerInfo để quản lý thông tin quản lý sự kiện
- Thêm API endpoint: getEventManagersByEventId để lấy danh sách quản lý
- Thêm SecretaryManagementBloc để quản lý state và logic cho thư ký
- Thêm UI components: SecretaryManagementSection, AddSecretaryDialog
- Tích hợp vào ToolsSettingsTab
- Cho phép Manager gán/xóa thư ký với role STAFF
- Thư ký được chọn từ danh sách người tham gia sự kiện