### PR TITLE
feat(EM-46): Triển khai chức năng thăm dò ý kiến

### DIFF
--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -31,6 +31,7 @@ import 'package:event_management/features/poll/presentation/bloc/create_poll/cre
 import 'package:event_management/features/poll/presentation/bloc/poll_list/poll_list_bloc.dart';
 import 'package:event_management/features/poll/presentation/bloc/poll_stats/poll_stats_bloc.dart';
 import 'package:event_management/features/poll/presentation/bloc/update_poll/update_poll_bloc.dart';
+import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_poll_bloc.dart';
 import 'package:event_management/features/unit/data/datasource/unit_api_client.dart';
 import 'package:event_management/features/unit/data/repository/unit_repository_impl.dart';
 import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
@@ -94,6 +95,7 @@ Future<void> init() async {
     ..registerFactory(() => PollListBloc(sl<PollRepository>()))
     ..registerFactory(() => PollStatsBloc(sl<PollRepository>()))
     ..registerFactory(() => UpdatePollBloc(sl<PollRepository>()))
+    ..registerFactory(() => VotePollBloc(sl<PollRepository>()))
     // Dio instances - Main Dio for general use (has auth interceptor)
     ..registerLazySingleton<Dio>(
       () =>

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -19,6 +19,7 @@ import 'package:event_management/features/event/event_detail/presentation/pages/
 import 'package:event_management/features/event/event_list/presentation/bloc/event_list_bloc.dart';
 import 'package:event_management/features/event/event_list/presentation/pages/event_list_screen.dart';
 import 'package:event_management/features/event/event_management/presentation/pages/event_management_screen.dart';
+import 'package:event_management/features/poll/presentation/pages/vote_poll_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -36,6 +37,7 @@ class AppRoutes {
   static const String userManagement = '/admin/user-management';
   static const String eventManagement = '/events/:id/manage';
   static const String adminEditEvent = '/admin/events/:id/edit';
+  static const String votePoll = '/polls/:id/vote';
 }
 
 final GoRouter appRouter = GoRouter(
@@ -179,6 +181,14 @@ final GoRouter appRouter = GoRouter(
             },
           ),
         );
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.votePoll,
+      name: AppRoutes.votePoll,
+      builder: (context, state) {
+        final pollId = int.parse(state.pathParameters['id']!);
+        return VotePollScreen(pollId: pollId);
       },
     ),
   ],

--- a/lib/features/event/event_detail/presentation/pages/event_detail_screen.dart
+++ b/lib/features/event/event_detail/presentation/pages/event_detail_screen.dart
@@ -5,8 +5,6 @@ import 'package:event_management/core/di/injection_container.dart' as di;
 import 'package:event_management/core/router/app_router.dart';
 import 'package:event_management/core/services/calendar_service.dart';
 import 'package:event_management/features/auth/domain/repositories/auth_repository.dart';
-import 'package:event_management/features/event/shared/data/models/event_detail_response.dart';
-import 'package:event_management/features/event/shared/data/models/event_status.dart';
 import 'package:event_management/features/event/event_detail/presentation/bloc/event_detail_bloc.dart';
 import 'package:event_management/features/event/event_detail/presentation/bloc/event_detail_event.dart';
 import 'package:event_management/features/event/event_detail/presentation/bloc/event_detail_state.dart';
@@ -18,6 +16,9 @@ import 'package:event_management/features/event/event_detail/presentation/widget
 import 'package:event_management/features/event/event_detail/presentation/widgets/event_detail/event_detail_status_chip.dart';
 import 'package:event_management/features/event/event_detail/presentation/widgets/event_detail/event_detail_title.dart';
 import 'package:event_management/features/event/event_detail/presentation/widgets/event_detail/qr_code_scanner_dialog.dart';
+import 'package:event_management/features/event/shared/data/models/event_detail_response.dart';
+import 'package:event_management/features/event/shared/data/models/event_status.dart';
+import 'package:event_management/features/poll/presentation/widgets/poll_list/poll_list_section_for_users.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -442,6 +443,14 @@ class _EventDetailContentState extends State<_EventDetailContent> {
                     ),
                   ),
 
+                const SizedBox(height: AppSpacing.spaceLG),
+
+                // Poll Section for users
+                PollListSectionForUsers(
+                  eventId: widget.eventDetail.id,
+                  isUserRegistered:
+                      widget.eventDetail.isUserRegistered ?? false,
+                ),
                 const SizedBox(height: AppSpacing.spaceLG),
               ],
             ),

--- a/lib/features/poll/data/datasources/poll_api_client.dart
+++ b/lib/features/poll/data/datasources/poll_api_client.dart
@@ -1,8 +1,11 @@
 import 'package:dio/dio.dart';
+import 'package:event_management/features/auth/data/models/message_response.dart';
 import 'package:event_management/features/poll/data/models/create_poll_dto.dart';
+import 'package:event_management/features/poll/data/models/my_voted_options_response.dart';
 import 'package:event_management/features/poll/data/models/poll_response.dart';
 import 'package:event_management/features/poll/data/models/poll_stats_response.dart';
 import 'package:event_management/features/poll/data/models/update_poll_dto.dart';
+import 'package:event_management/features/poll/data/models/vote_poll_dto.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -36,4 +39,13 @@ abstract class PollApiClient {
     @Path('pollId') int pollId,
     @Body() UpdatePollDto updatePollDto,
   );
+
+  @POST('/polls/{pollId}/vote')
+  Future<MessageResponse> votePoll(
+    @Path('pollId') int pollId,
+    @Body() VotePollDto votePollDto,
+  );
+
+  @GET('/polls/{pollId}/my-options')
+  Future<MyVotedOptionsResponse> getMyVotedOptions(@Path('pollId') int pollId);
 }

--- a/lib/features/poll/data/datasources/poll_api_client.g.dart
+++ b/lib/features/poll/data/datasources/poll_api_client.g.dart
@@ -193,6 +193,61 @@ class _PollApiClient implements PollApiClient {
     return _value;
   }
 
+  @override
+  Future<MessageResponse> votePoll(int pollId, VotePollDto votePollDto) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(votePollDto.toJson());
+    final _options = _setStreamType<MessageResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/polls/${pollId}/vote',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MessageResponse _value;
+    try {
+      _value = MessageResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<MyVotedOptionsResponse> getMyVotedOptions(int pollId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<MyVotedOptionsResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/polls/${pollId}/my-options',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MyVotedOptionsResponse _value;
+    try {
+      _value = MyVotedOptionsResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/poll/data/models/my_voted_options_response.dart
+++ b/lib/features/poll/data/models/my_voted_options_response.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'my_voted_options_response.g.dart';
+
+@JsonSerializable()
+class MyVotedOptionsResponse extends Equatable {
+  const MyVotedOptionsResponse({required this.optionIds});
+
+  factory MyVotedOptionsResponse.fromJson(Map<String, dynamic> json) =>
+      _$MyVotedOptionsResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MyVotedOptionsResponseToJson(this);
+
+  @JsonKey(name: 'optionIds')
+  final List<int> optionIds;
+
+  @override
+  List<Object?> get props => [optionIds];
+}

--- a/lib/features/poll/data/models/my_voted_options_response.g.dart
+++ b/lib/features/poll/data/models/my_voted_options_response.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'my_voted_options_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MyVotedOptionsResponse _$MyVotedOptionsResponseFromJson(
+  Map<String, dynamic> json,
+) => MyVotedOptionsResponse(
+  optionIds: (json['optionIds'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$MyVotedOptionsResponseToJson(
+  MyVotedOptionsResponse instance,
+) => <String, dynamic>{'optionIds': instance.optionIds};

--- a/lib/features/poll/data/models/vote_poll_dto.dart
+++ b/lib/features/poll/data/models/vote_poll_dto.dart
@@ -1,0 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'vote_poll_dto.g.dart';
+
+@JsonSerializable()
+class VotePollDto {
+  const VotePollDto({required this.optionIds});
+
+  factory VotePollDto.fromJson(Map<String, dynamic> json) =>
+      _$VotePollDtoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VotePollDtoToJson(this);
+
+  @JsonKey(name: 'option_ids')
+  final List<int> optionIds;
+}
+

--- a/lib/features/poll/data/models/vote_poll_dto.g.dart
+++ b/lib/features/poll/data/models/vote_poll_dto.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vote_poll_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VotePollDto _$VotePollDtoFromJson(Map<String, dynamic> json) => VotePollDto(
+  optionIds: (json['option_ids'] as List<dynamic>)
+      .map((e) => (e as num).toInt())
+      .toList(),
+);
+
+Map<String, dynamic> _$VotePollDtoToJson(VotePollDto instance) =>
+    <String, dynamic>{'option_ids': instance.optionIds};

--- a/lib/features/poll/data/repositories/poll_repository_impl.dart
+++ b/lib/features/poll/data/repositories/poll_repository_impl.dart
@@ -1,9 +1,11 @@
 import 'package:dio/dio.dart';
 import 'package:event_management/features/poll/data/datasources/poll_api_client.dart';
 import 'package:event_management/features/poll/data/models/create_poll_dto.dart';
+import 'package:event_management/features/poll/data/models/my_voted_options_response.dart';
 import 'package:event_management/features/poll/data/models/poll_response.dart';
 import 'package:event_management/features/poll/data/models/poll_stats_response.dart';
 import 'package:event_management/features/poll/data/models/update_poll_dto.dart';
+import 'package:event_management/features/poll/data/models/vote_poll_dto.dart';
 import 'package:event_management/features/poll/domain/repositories/poll_repository.dart';
 import 'package:injectable/injectable.dart';
 
@@ -141,6 +143,45 @@ class PollRepositoryImpl implements PollRepository {
       if (e.response?.data != null && e.response!.data is Map) {
         final errorMessage = e.response!.data['message'] as String?;
         throw Exception(errorMessage ?? 'Không thể cập nhật poll.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<PollResponse> votePoll(int pollId, VotePollDto votePollDto) async {
+    try {
+      // Vote API returns MessageResponse, not PollResponse
+      await _pollApiClient.votePoll(pollId, votePollDto);
+      // After successful vote, fetch the poll again to get updated data
+      return await _pollApiClient.getPoll(pollId);
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể bỏ phiếu.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      // Re-throw if it's already an Exception
+      if (e is Exception) {
+        rethrow;
+      }
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<MyVotedOptionsResponse> getMyVotedOptions(int pollId) async {
+    try {
+      return await _pollApiClient.getMyVotedOptions(pollId);
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(
+          errorMessage ?? 'Không thể lấy danh sách option đã vote.',
+        );
       }
       throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
     } catch (e) {

--- a/lib/features/poll/domain/repositories/poll_repository.dart
+++ b/lib/features/poll/domain/repositories/poll_repository.dart
@@ -1,7 +1,9 @@
 import 'package:event_management/features/poll/data/models/create_poll_dto.dart';
+import 'package:event_management/features/poll/data/models/my_voted_options_response.dart';
 import 'package:event_management/features/poll/data/models/poll_response.dart';
 import 'package:event_management/features/poll/data/models/poll_stats_response.dart';
 import 'package:event_management/features/poll/data/models/update_poll_dto.dart';
+import 'package:event_management/features/poll/data/models/vote_poll_dto.dart';
 
 abstract class PollRepository {
   /// Tạo poll mới
@@ -21,4 +23,10 @@ abstract class PollRepository {
 
   /// Cập nhật poll
   Future<PollResponse> updatePoll(int pollId, UpdatePollDto updatePollDto);
+
+  /// Bỏ phiếu cho poll
+  Future<PollResponse> votePoll(int pollId, VotePollDto votePollDto);
+
+  /// Lấy danh sách option IDs mà user đã vote
+  Future<MyVotedOptionsResponse> getMyVotedOptions(int pollId);
 }

--- a/lib/features/poll/presentation/bloc/vote_poll/vote_poll_bloc.dart
+++ b/lib/features/poll/presentation/bloc/vote_poll/vote_poll_bloc.dart
@@ -1,0 +1,62 @@
+import 'package:bloc/bloc.dart';
+import 'package:event_management/features/poll/data/models/vote_poll_dto.dart';
+import 'package:event_management/features/poll/domain/repositories/poll_repository.dart';
+import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_poll_event.dart';
+import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_poll_state.dart';
+import 'package:injectable/injectable.dart';
+
+/// BLoC để quản lý state của việc bỏ phiếu poll
+@injectable
+class VotePollBloc extends Bloc<VotePollEvent, VotePollState> {
+  VotePollBloc(this._pollRepository) : super(const VotePollInitial()) {
+    on<VotePollFetched>(_onFetched);
+    on<VotePollSubmitted>(_onSubmitted);
+    on<MyVotedOptionsFetched>(_onMyVotedOptionsFetched);
+  }
+
+  final PollRepository _pollRepository;
+
+  Future<void> _onFetched(
+    VotePollFetched event,
+    Emitter<VotePollState> emit,
+  ) async {
+    emit(const VotePollLoading());
+
+    try {
+      final poll = await _pollRepository.getPoll(event.pollId);
+      emit(VotePollSuccess(poll));
+    } catch (e) {
+      emit(VotePollError(e.toString()));
+    }
+  }
+
+  Future<void> _onSubmitted(
+    VotePollSubmitted event,
+    Emitter<VotePollState> emit,
+  ) async {
+    emit(const VotePollLoading());
+
+    try {
+      final voteDto = VotePollDto(optionIds: event.optionIds);
+      final poll = await _pollRepository.votePoll(event.pollId, voteDto);
+      emit(VotePollSuccess(poll));
+    } catch (e) {
+      emit(VotePollError(e.toString()));
+    }
+  }
+
+  Future<void> _onMyVotedOptionsFetched(
+    MyVotedOptionsFetched event,
+    Emitter<VotePollState> emit,
+  ) async {
+    try {
+      final myVotedOptions = await _pollRepository.getMyVotedOptions(
+        event.pollId,
+      );
+      emit(MyVotedOptionsSuccess(myVotedOptions));
+    } catch (e) {
+      // Don't emit error state, just silently fail
+      // This is optional data
+    }
+  }
+}

--- a/lib/features/poll/presentation/bloc/vote_poll/vote_poll_event.dart
+++ b/lib/features/poll/presentation/bloc/vote_poll/vote_poll_event.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+
+abstract class VotePollEvent extends Equatable {
+  const VotePollEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class VotePollFetched extends VotePollEvent {
+  const VotePollFetched(this.pollId);
+
+  final int pollId;
+
+  @override
+  List<Object?> get props => [pollId];
+}
+
+class VotePollSubmitted extends VotePollEvent {
+  const VotePollSubmitted({required this.pollId, required this.optionIds});
+
+  final int pollId;
+  final List<int> optionIds;
+
+  @override
+  List<Object?> get props => [pollId, optionIds];
+}
+
+class MyVotedOptionsFetched extends VotePollEvent {
+  const MyVotedOptionsFetched(this.pollId);
+
+  final int pollId;
+
+  @override
+  List<Object?> get props => [pollId];
+}

--- a/lib/features/poll/presentation/bloc/vote_poll/vote_poll_state.dart
+++ b/lib/features/poll/presentation/bloc/vote_poll/vote_poll_state.dart
@@ -1,0 +1,45 @@
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/poll/data/models/my_voted_options_response.dart';
+import 'package:event_management/features/poll/data/models/poll_response.dart';
+
+abstract class VotePollState extends Equatable {
+  const VotePollState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class VotePollInitial extends VotePollState {
+  const VotePollInitial();
+}
+
+class VotePollLoading extends VotePollState {
+  const VotePollLoading();
+}
+
+class VotePollSuccess extends VotePollState {
+  const VotePollSuccess(this.poll);
+
+  final PollResponse poll;
+
+  @override
+  List<Object?> get props => [poll];
+}
+
+class VotePollError extends VotePollState {
+  const VotePollError(this.message);
+
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class MyVotedOptionsSuccess extends VotePollState {
+  const MyVotedOptionsSuccess(this.myVotedOptions);
+
+  final MyVotedOptionsResponse myVotedOptions;
+
+  @override
+  List<Object?> get props => [myVotedOptions];
+}

--- a/lib/features/poll/presentation/pages/vote_poll_screen.dart
+++ b/lib/features/poll/presentation/pages/vote_poll_screen.dart
@@ -1,0 +1,836 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/features/event/shared/domain/repositories/event_repository.dart';
+import 'package:event_management/features/poll/data/models/poll_response.dart';
+import 'package:event_management/features/poll/domain/entities/poll_type.dart';
+import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_poll_bloc.dart';
+import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_poll_event.dart';
+import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_poll_state.dart';
+import 'package:event_management/features/poll/presentation/widgets/vote_poll/poll_option_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+/// Screen để người dùng bỏ phiếu trong poll
+class VotePollScreen extends StatelessWidget {
+  const VotePollScreen({required this.pollId, super.key});
+
+  final int pollId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => di.sl<VotePollBloc>()..add(VotePollFetched(pollId)),
+      child: _VotePollView(pollId: pollId),
+    );
+  }
+}
+
+class _VotePollView extends StatefulWidget {
+  const _VotePollView({required this.pollId});
+
+  final int pollId;
+
+  @override
+  State<_VotePollView> createState() => _VotePollViewState();
+}
+
+class _VotePollViewState extends State<_VotePollView> {
+  Set<int> _selectedOptionIds = <int>{};
+  bool? _isUserRegistered;
+  bool _isCheckingPermission = false;
+  bool _hasVoted = false;
+  Set<int> _myVotedOptionIds = <int>{};
+  PollResponse? _currentPoll;
+
+  Future<void> _checkUserPermission(int eventId) async {
+    if (_isCheckingPermission) return;
+
+    setState(() {
+      _isCheckingPermission = true;
+    });
+
+    try {
+      final eventRepository = di.sl<EventRepository>();
+      final eventDetail = await eventRepository.getEventDetail(eventId);
+      if (mounted) {
+        setState(() {
+          _isUserRegistered = eventDetail.isUserRegistered ?? false;
+          _isCheckingPermission = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isUserRegistered = false;
+          _isCheckingPermission = false;
+        });
+      }
+    }
+  }
+
+  void _toggleOption(int optionId, PollType pollType) {
+    setState(() {
+      if (pollType == PollType.singleChoice) {
+        _selectedOptionIds.clear();
+        _selectedOptionIds.add(optionId);
+      } else {
+        if (_selectedOptionIds.contains(optionId)) {
+          _selectedOptionIds.remove(optionId);
+        } else {
+          _selectedOptionIds.add(optionId);
+        }
+      }
+    });
+  }
+
+  void _handleSubmit(BuildContext context, int pollId) {
+    if (_selectedOptionIds.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Vui lòng chọn ít nhất một lựa chọn'),
+          backgroundColor: AppColors.red500,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    if (_isUserRegistered == false) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Bạn cần tham gia sự kiện trước khi bỏ phiếu'),
+          backgroundColor: AppColors.red500,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    _hasVoted = true; // Set flag before submitting
+    context.read<VotePollBloc>().add(
+      VotePollSubmitted(pollId: pollId, optionIds: _selectedOptionIds.toList()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: BlocConsumer<VotePollBloc, VotePollState>(
+        listener: (context, state) {
+          if (state is VotePollError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.red500,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          } else if (state is VotePollSuccess) {
+            // Save current poll to widget state
+            _currentPoll = state.poll;
+
+            // Fetch my voted options when poll is loaded
+            if (state.poll.hasVoted && _myVotedOptionIds.isEmpty) {
+              context.read<VotePollBloc>().add(
+                MyVotedOptionsFetched(state.poll.id),
+              );
+            }
+
+            if (_hasVoted) {
+              // Vote was successful
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Bỏ phiếu thành công!'),
+                  backgroundColor: AppColors.green500,
+                  behavior: SnackBarBehavior.floating,
+                ),
+              );
+              // Pop back after a short delay
+              Future.delayed(const Duration(milliseconds: 500), () {
+                if (mounted) {
+                  Navigator.of(context).pop(true);
+                }
+              });
+              _hasVoted = false; // Reset flag
+            }
+          } else if (state is MyVotedOptionsSuccess) {
+            // Update selected options with my voted options
+            setState(() {
+              _myVotedOptionIds = state.myVotedOptions.optionIds.toSet();
+              _selectedOptionIds = _myVotedOptionIds.toSet();
+            });
+          }
+        },
+        builder: (context, state) {
+          if (state is VotePollLoading && state is! VotePollSuccess) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+
+          if (state is VotePollError) {
+            return Scaffold(
+              appBar: AppBar(
+                title: const Text('Bỏ phiếu'),
+                backgroundColor: AppColors.vkuBlue,
+                foregroundColor: AppColors.white,
+              ),
+              body: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      size: 64,
+                      color: AppColors.red500,
+                    ),
+                    const SizedBox(height: AppSpacing.spaceMD),
+                    Text('Không thể tải poll', style: AppTextStyles.heading4),
+                    const SizedBox(height: AppSpacing.spaceXS),
+                    Text(
+                      state.message,
+                      style: AppTextStyles.bodySmall.copyWith(
+                        color: AppColors.coolGray500,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: AppSpacing.spaceLG),
+                    ElevatedButton(
+                      onPressed: () {
+                        context.read<VotePollBloc>().add(
+                          VotePollFetched(widget.pollId),
+                        );
+                      },
+                      child: const Text('Thử lại'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          // Handle MyVotedOptionsSuccess - use saved poll if available
+          if (state is MyVotedOptionsSuccess && _currentPoll != null) {
+            final poll = _currentPoll!;
+            const isLoading = false;
+            return _buildPollContent(
+              context: context,
+              poll: poll,
+              isLoading: isLoading,
+            );
+          }
+
+          if (state is VotePollSuccess) {
+            final poll = state.poll;
+            const isLoading = false;
+
+            // If user has already voted, no need to check permission
+            // Just show the poll content with voted options
+            if (poll.hasVoted) {
+              // Fetch my voted options if not already fetched
+              if (_myVotedOptionIds.isEmpty) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  context.read<VotePollBloc>().add(
+                    MyVotedOptionsFetched(poll.id),
+                  );
+                });
+              }
+              return _buildPollContent(
+                context: context,
+                poll: poll,
+                isLoading: isLoading,
+              );
+            }
+
+            // Check permission on first load (after build phase) only if not voted
+            if (_isUserRegistered == null && !_isCheckingPermission) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                _checkUserPermission(poll.eventId);
+              });
+            }
+
+            // Show loading while checking permission
+            if (_isCheckingPermission || _isUserRegistered == null) {
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+
+            return _buildPollContent(
+              context: context,
+              poll: poll,
+              isLoading: isLoading,
+            );
+          }
+
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildPollContent({
+    required BuildContext context,
+    required PollResponse poll,
+    required bool isLoading,
+  }) {
+    final now = DateTime.now();
+    final isPollActive =
+        !poll.isDelete &&
+        now.isAfter(poll.startTime) &&
+        now.isBefore(poll.endTime);
+    final canVote =
+        isPollActive && !poll.hasVoted && (_isUserRegistered ?? false);
+
+    return CustomScrollView(
+      slivers: [
+        // App Bar với gradient
+        SliverAppBar(
+          expandedHeight: 200,
+          pinned: true,
+          backgroundColor: AppColors.vkuBlue,
+          foregroundColor: AppColors.white,
+          flexibleSpace: LayoutBuilder(
+            builder: (context, constraints) {
+              final isCollapsed = constraints.maxHeight <= 120;
+              return FlexibleSpaceBar(
+                title: isCollapsed
+                    ? Text(
+                        poll.title,
+                        style: AppTextStyles.heading5.copyWith(
+                          color: AppColors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : null,
+                centerTitle: false,
+                titlePadding: const EdgeInsets.only(left: 16, bottom: 16),
+                background: Container(
+                  decoration: BoxDecoration(
+                    gradient: AppColors.primaryGradient,
+                  ),
+                  child: SafeArea(
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSpacing.spaceLG),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: AppColors.white.withValues(alpha: 0.2),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: const Icon(
+                              Icons.poll_rounded,
+                              color: AppColors.white,
+                              size: 32,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.spaceMD),
+                          Text(
+                            'Bỏ phiếu',
+                            style: AppTextStyles.bodySmall.copyWith(
+                              color: AppColors.white.withValues(alpha: 0.9),
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.spaceXS),
+                          Text(
+                            poll.title,
+                            style: AppTextStyles.heading3.copyWith(
+                              color: AppColors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+
+        // Content
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.spaceLG),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Poll Info Card
+                _PollInfoCard(poll: poll),
+                const SizedBox(height: AppSpacing.spaceLG),
+
+                // Status Badge
+                _PollStatusBadge(
+                  isActive: isPollActive,
+                  hasVoted: poll.hasVoted,
+                ),
+                const SizedBox(height: AppSpacing.spaceLG),
+
+                // Options
+                if (canVote) ...[
+                  Text(
+                    poll.pollType == PollType.singleChoice
+                        ? 'Chọn một lựa chọn'
+                        : 'Chọn một hoặc nhiều lựa chọn',
+                    style: AppTextStyles.heading5.copyWith(
+                      color: AppColors.coolGray700,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.spaceMD),
+                  ...poll.options.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final option = entry.value;
+                    final isSelected = _selectedOptionIds.contains(option.id);
+
+                    return Padding(
+                      padding: EdgeInsets.only(
+                        bottom: index < poll.options.length - 1
+                            ? AppSpacing.spaceMD
+                            : 0,
+                      ),
+                      child: PollOptionCard(
+                        option: option,
+                        isSelected: isSelected,
+                        pollType: poll.pollType,
+                        onTap: () => _toggleOption(option.id, poll.pollType),
+                      ),
+                    );
+                  }),
+                  const SizedBox(height: AppSpacing.spaceXL),
+                ] else if (poll.hasVoted) ...[
+                  // Show voted options
+                  Text(
+                    'Lựa chọn của bạn',
+                    style: AppTextStyles.heading5.copyWith(
+                      color: AppColors.coolGray700,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.spaceMD),
+                  ...poll.options.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final option = entry.value;
+                    final isMyVote = _myVotedOptionIds.contains(option.id);
+
+                    return Padding(
+                      padding: EdgeInsets.only(
+                        bottom: index < poll.options.length - 1
+                            ? AppSpacing.spaceMD
+                            : 0,
+                      ),
+                      child: PollOptionCard(
+                        option: option,
+                        isSelected: isMyVote,
+                        pollType: poll.pollType,
+                        onTap: () {}, // Disabled when already voted
+                      ),
+                    );
+                  }),
+                  const SizedBox(height: AppSpacing.spaceLG),
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.spaceLG),
+                    decoration: BoxDecoration(
+                      color: AppColors.green50,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: AppColors.green500.withValues(alpha: 0.3),
+                        width: 2,
+                      ),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.check_circle_rounded,
+                          color: AppColors.green500,
+                          size: 32,
+                        ),
+                        const SizedBox(width: AppSpacing.spaceMD),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Bạn đã bỏ phiếu',
+                                style: AppTextStyles.heading5.copyWith(
+                                  color: AppColors.green800,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                'Cảm ơn bạn đã tham gia bỏ phiếu!',
+                                style: AppTextStyles.bodySmall.copyWith(
+                                  color: AppColors.green800,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ] else if (!(_isUserRegistered ?? false) && isPollActive) ...[
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.spaceLG),
+                    decoration: BoxDecoration(
+                      color: AppColors.amber100,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: AppColors.amber400.withValues(alpha: 0.3),
+                        width: 2,
+                      ),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.info_outline_rounded,
+                          color: AppColors.amber600,
+                          size: 32,
+                        ),
+                        const SizedBox(width: AppSpacing.spaceMD),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Cần tham gia sự kiện',
+                                style: AppTextStyles.heading5.copyWith(
+                                  color: AppColors.amber800,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                'Bạn cần tham gia sự kiện trước khi có thể bỏ phiếu',
+                                style: AppTextStyles.bodySmall.copyWith(
+                                  color: AppColors.amber800,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ] else ...[
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.spaceLG),
+                    decoration: BoxDecoration(
+                      color: AppColors.coolGray50,
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.info_outline_rounded,
+                          color: AppColors.coolGray500,
+                          size: 32,
+                        ),
+                        const SizedBox(width: AppSpacing.spaceMD),
+                        Expanded(
+                          child: Text(
+                            isPollActive
+                                ? 'Poll này đã kết thúc'
+                                : 'Poll này chưa bắt đầu hoặc đã kết thúc',
+                            style: AppTextStyles.bodyMedium.copyWith(
+                              color: AppColors.coolGray700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+
+                // Submit Button
+                if (canVote) ...[
+                  const SizedBox(height: AppSpacing.spaceLG),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: isLoading
+                          ? null
+                          : () => _handleSubmit(context, poll.id),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.vkuBlue,
+                        foregroundColor: AppColors.white,
+                        padding: const EdgeInsets.symmetric(
+                          vertical: AppSpacing.spaceMD,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        elevation: 0,
+                      ),
+                      child: isLoading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                color: AppColors.white,
+                                strokeWidth: 2,
+                              ),
+                            )
+                          : Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const Icon(Icons.how_to_vote_rounded, size: 20),
+                                const SizedBox(width: AppSpacing.spaceXM),
+                                Text(
+                                  'Xác nhận bỏ phiếu',
+                                  style: AppTextStyles.heading5.copyWith(
+                                    color: AppColors.white,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                    ),
+                  ),
+                ],
+                const SizedBox(height: AppSpacing.spaceXL),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Widget hiển thị thông tin poll
+class _PollInfoCard extends StatelessWidget {
+  const _PollInfoCard({required this.poll});
+
+  final PollResponse poll;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.spaceMD),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 1.5),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.coolGray900.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: AppColors.amber100,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Icon(
+                  Icons.poll_rounded,
+                  color: AppColors.amber600,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.spaceMD),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      poll.pollType.label,
+                      style: AppTextStyles.bodySmall.copyWith(
+                        color: AppColors.amber600,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '${poll.options.length} lựa chọn',
+                      style: AppTextStyles.caption.copyWith(
+                        color: AppColors.coolGray500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const Divider(height: 24),
+          _InfoRow(
+            icon: Icons.access_time_rounded,
+            label: 'Bắt đầu',
+            value: DateFormat('dd/MM/yyyy HH:mm', 'vi').format(poll.startTime),
+          ),
+          const SizedBox(height: AppSpacing.spaceXM),
+          _InfoRow(
+            icon: Icons.event_available_rounded,
+            label: 'Kết thúc',
+            value: DateFormat('dd/MM/yyyy HH:mm', 'vi').format(poll.endTime),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: AppColors.coolGray500),
+        const SizedBox(width: AppSpacing.spaceXM),
+        Text(
+          '$label: ',
+          style: AppTextStyles.bodySmall.copyWith(color: AppColors.coolGray500),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: AppTextStyles.bodySmall.copyWith(
+              color: AppColors.coolGray900,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Widget hiển thị status badge
+class _PollStatusBadge extends StatelessWidget {
+  const _PollStatusBadge({required this.isActive, required this.hasVoted});
+
+  final bool isActive;
+  final bool hasVoted;
+
+  @override
+  Widget build(BuildContext context) {
+    if (hasVoted) {
+      return Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.spaceMD,
+          vertical: AppSpacing.spaceXM,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.green50,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: AppColors.green500, width: 1.5),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.check_circle_rounded,
+              color: AppColors.green500,
+              size: 16,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              'Đã bỏ phiếu',
+              style: AppTextStyles.bodySmall.copyWith(
+                color: AppColors.green800,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (isActive) {
+      return Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.spaceMD,
+          vertical: AppSpacing.spaceXM,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.blue50,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: AppColors.blue400, width: 1.5),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.radio_button_checked_rounded,
+              color: AppColors.blue400,
+              size: 16,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              'Đang diễn ra',
+              style: AppTextStyles.bodySmall.copyWith(
+                color: AppColors.vkuBlue,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.spaceMD,
+        vertical: AppSpacing.spaceXM,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.coolGray50,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppColors.coolGray500, width: 1.5),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.cancel_rounded,
+            color: AppColors.coolGray500,
+            size: 16,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            'Đã kết thúc',
+            style: AppTextStyles.bodySmall.copyWith(
+              color: AppColors.coolGray700,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/poll/presentation/widgets/poll_list/poll_list_section.dart
+++ b/lib/features/poll/presentation/widgets/poll_list/poll_list_section.dart
@@ -2,6 +2,7 @@ import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
 import 'package:event_management/core/config/app_text_styles.dart';
 import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/core/router/app_router.dart';
 import 'package:event_management/features/poll/data/models/poll_response.dart';
 import 'package:event_management/features/poll/presentation/bloc/poll_list/poll_list_bloc.dart';
 import 'package:event_management/features/poll/presentation/bloc/poll_list/poll_list_event.dart';
@@ -10,6 +11,7 @@ import 'package:event_management/features/poll/presentation/widgets/poll_list/po
 import 'package:event_management/features/poll/presentation/widgets/poll_list/update_poll_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 class PollListSection extends StatelessWidget {
@@ -145,6 +147,21 @@ class PollListSection extends StatelessWidget {
             onViewStats: () => _showStatsDialog(context, poll.id),
             onUpdate: () => _showUpdatePollBottomSheet(context, poll),
             onClose: () => _showCloseConfirmation(context, poll),
+            onVote: () {
+              context
+                  .pushNamed(
+                    AppRoutes.votePoll,
+                    pathParameters: {'id': poll.id.toString()},
+                  )
+                  .then((result) {
+                    // Refresh poll list after voting
+                    if (result == true) {
+                      context.read<PollListBloc>().add(
+                        PollListRefreshed(eventId),
+                      );
+                    }
+                  });
+            },
           );
         },
       ),
@@ -264,12 +281,14 @@ class _PollListItem extends StatelessWidget {
     required this.onViewStats,
     required this.onUpdate,
     required this.onClose,
+    required this.onVote,
   });
 
   final PollResponse poll;
   final VoidCallback onViewStats;
   final VoidCallback onUpdate;
   final VoidCallback onClose;
+  final VoidCallback onVote;
 
   String _getStatusText() {
     if (poll.isDelete) return 'Đã đóng';
@@ -291,112 +310,267 @@ class _PollListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final statusText = _getStatusText();
     final statusColor = _getStatusColor();
+    final now = DateTime.now();
+    final isPollActive =
+        !poll.isDelete &&
+        now.isAfter(poll.startTime) &&
+        now.isBefore(poll.endTime);
+    final canVote = isPollActive && !poll.hasVoted;
 
-    return ListTile(
-      contentPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.spaceMD,
-        vertical: AppSpacing.spaceXS,
-      ),
-      leading: Container(
-        padding: const EdgeInsets.all(12),
+    return InkWell(
+      onTap: canVote ? onVote : null,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.all(AppSpacing.spaceMD),
         decoration: BoxDecoration(
-          color: AppColors.amber100,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: const Icon(
-          Icons.poll_rounded,
-          color: AppColors.amber600,
-          size: 24,
-        ),
-      ),
-      title: Text(poll.title, style: AppTextStyles.heading5),
-      subtitle: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: 4),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.circle, size: 8, color: statusColor),
-              const SizedBox(width: 4),
-              Flexible(
-                child: Text(
-                  statusText,
-                  style: AppTextStyles.bodySmall.copyWith(color: statusColor),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              const SizedBox(width: AppSpacing.spaceMD),
-              Flexible(
-                child: Text(
-                  poll.pollType.label,
-                  style: AppTextStyles.bodySmall.copyWith(
-                    color: AppColors.coolGray500,
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: canVote
+              ? Border.all(
+                  color: AppColors.vkuBlue.withValues(alpha: 0.2),
+                  width: 1.5,
+                )
+              : null,
+          boxShadow: canVote
+              ? [
+                  BoxShadow(
+                    color: AppColors.vkuBlue.withValues(alpha: 0.1),
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
+                ]
+              : null,
+        ),
+        child: Row(
+          children: [
+            // Leading icon
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppColors.amber100,
+                borderRadius: BorderRadius.circular(8),
               ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          Text(
-            '${DateFormat('dd/MM/yyyy HH:mm', 'vi').format(poll.startTime)} - ${DateFormat('dd/MM/yyyy HH:mm', 'vi').format(poll.endTime)}',
-            style: AppTextStyles.bodySmall.copyWith(
-              color: AppColors.coolGray500,
+              child: const Icon(
+                Icons.poll_rounded,
+                color: AppColors.amber600,
+                size: 24,
+              ),
             ),
-          ),
-        ],
-      ),
-      trailing: PopupMenuButton<String>(
-        icon: const Icon(Icons.more_vert),
-        onSelected: (value) {
-          switch (value) {
-            case 'stats':
-              onViewStats();
-            case 'update':
-              onUpdate();
-            case 'close':
-              if (!poll.isDelete) {
-                onClose();
-              }
-          }
-        },
-        itemBuilder: (context) => [
-          const PopupMenuItem(
-            value: 'stats',
-            child: Row(
+            const SizedBox(width: AppSpacing.spaceMD),
+
+            // Content
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          poll.title,
+                          style: AppTextStyles.heading5.copyWith(
+                            color: canVote
+                                ? AppColors.vkuBlue
+                                : AppColors.coolGray900,
+                            fontWeight: canVote
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.circle, size: 8, color: statusColor),
+                      const SizedBox(width: 4),
+                      Flexible(
+                        child: Text(
+                          statusText,
+                          style: AppTextStyles.bodySmall.copyWith(
+                            color: statusColor,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.spaceMD),
+                      Flexible(
+                        child: Text(
+                          poll.pollType.label,
+                          style: AppTextStyles.bodySmall.copyWith(
+                            color: AppColors.coolGray500,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${DateFormat('dd/MM/yyyy HH:mm', 'vi').format(poll.startTime)} - ${DateFormat('dd/MM/yyyy HH:mm', 'vi').format(poll.endTime)}',
+                    style: AppTextStyles.bodySmall.copyWith(
+                      color: AppColors.coolGray500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Trailing actions
+            Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(Icons.bar_chart_rounded, size: 20),
-                SizedBox(width: 8),
-                Text('Xem thống kê'),
+                // Vote button - nổi bật hơn
+                if (canVote) ...[
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.spaceMD,
+                      vertical: AppSpacing.spaceXM,
+                    ),
+                    decoration: BoxDecoration(
+                      gradient: AppColors.primaryGradient,
+                      borderRadius: BorderRadius.circular(8),
+                      boxShadow: [
+                        BoxShadow(
+                          color: AppColors.vkuBlue.withValues(alpha: 0.3),
+                          blurRadius: 4,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.how_to_vote_rounded,
+                          color: AppColors.white,
+                          size: 18,
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          'Bỏ phiếu',
+                          style: AppTextStyles.bodySmall.copyWith(
+                            color: AppColors.white,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.spaceXM),
+                ] else if (poll.hasVoted) ...[
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.spaceMD,
+                      vertical: AppSpacing.spaceXM,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.green50,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: AppColors.green500, width: 1.5),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(
+                          Icons.check_circle_rounded,
+                          color: AppColors.green500,
+                          size: 18,
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          'Đã bỏ phiếu',
+                          style: AppTextStyles.bodySmall.copyWith(
+                            color: AppColors.green800,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.spaceXM),
+                ],
+                // More options menu
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert),
+                  onSelected: (value) {
+                    switch (value) {
+                      case 'vote':
+                        onVote();
+                      case 'stats':
+                        onViewStats();
+                      case 'update':
+                        onUpdate();
+                      case 'close':
+                        if (!poll.isDelete) {
+                          onClose();
+                        }
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    if (canVote)
+                      const PopupMenuItem(
+                        value: 'vote',
+                        child: Row(
+                          children: [
+                            Icon(Icons.how_to_vote_rounded, size: 20),
+                            SizedBox(width: 8),
+                            Text('Bỏ phiếu'),
+                          ],
+                        ),
+                      ),
+                    const PopupMenuItem(
+                      value: 'stats',
+                      child: Row(
+                        children: [
+                          Icon(Icons.bar_chart_rounded, size: 20),
+                          SizedBox(width: 8),
+                          Text('Xem thống kê'),
+                        ],
+                      ),
+                    ),
+                    if (!poll.isDelete)
+                      const PopupMenuItem(
+                        value: 'update',
+                        child: Row(
+                          children: [
+                            Icon(Icons.edit_rounded, size: 20),
+                            SizedBox(width: 8),
+                            Text('Chỉnh sửa'),
+                          ],
+                        ),
+                      ),
+                    if (!poll.isDelete)
+                      const PopupMenuItem(
+                        value: 'close',
+                        child: Row(
+                          children: [
+                            Icon(
+                              Icons.close_rounded,
+                              size: 20,
+                              color: AppColors.red500,
+                            ),
+                            SizedBox(width: 8),
+                            Text(
+                              'Đóng poll',
+                              style: TextStyle(color: AppColors.red500),
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
               ],
             ),
-          ),
-          if (!poll.isDelete)
-            const PopupMenuItem(
-              value: 'update',
-              child: Row(
-                children: [
-                  Icon(Icons.edit_rounded, size: 20),
-                  SizedBox(width: 8),
-                  Text('Chỉnh sửa'),
-                ],
-              ),
-            ),
-          if (!poll.isDelete)
-            const PopupMenuItem(
-              value: 'close',
-              child: Row(
-                children: [
-                  Icon(Icons.close_rounded, size: 20, color: AppColors.red500),
-                  SizedBox(width: 8),
-                  Text('Đóng poll', style: TextStyle(color: AppColors.red500)),
-                ],
-              ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/poll/presentation/widgets/poll_list/poll_list_section_for_users.dart
+++ b/lib/features/poll/presentation/widgets/poll_list/poll_list_section_for_users.dart
@@ -1,0 +1,471 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/core/router/app_router.dart';
+import 'package:event_management/features/poll/data/models/poll_response.dart';
+import 'package:event_management/features/poll/presentation/bloc/poll_list/poll_list_bloc.dart';
+import 'package:event_management/features/poll/presentation/bloc/poll_list/poll_list_event.dart';
+import 'package:event_management/features/poll/presentation/bloc/poll_list/poll_list_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+/// Section hiển thị danh sách polls cho người dùng thường (không phải manager)
+class PollListSectionForUsers extends StatelessWidget {
+  const PollListSectionForUsers({
+    required this.eventId,
+    required this.isUserRegistered,
+    super.key,
+  });
+
+  final int eventId;
+  final bool isUserRegistered;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => di.sl<PollListBloc>()..add(PollListFetched(eventId)),
+      child: BlocConsumer<PollListBloc, PollListState>(
+        listener: (context, state) {
+          if (state is PollListError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.red500,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          return Container(
+            margin: const EdgeInsets.symmetric(horizontal: AppSpacing.spaceMD),
+            padding: const EdgeInsets.all(AppSpacing.spaceLG),
+            decoration: BoxDecoration(
+              color: AppColors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.coolGray900.withValues(alpha: 0.08),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: AppColors.amber100,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Icon(
+                            Icons.poll_rounded,
+                            color: AppColors.amber600,
+                            size: 20,
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.spaceMD),
+                        Text('Bình chọn', style: AppTextStyles.heading3),
+                      ],
+                    ),
+                    if (state is PollListLoading)
+                      const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    else
+                      IconButton(
+                        icon: const Icon(Icons.refresh_rounded),
+                        onPressed: () {
+                          context.read<PollListBloc>().add(
+                            PollListRefreshed(eventId),
+                          );
+                        },
+                        tooltip: 'Làm mới',
+                        iconSize: 20,
+                      ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.spaceMD),
+                if (state is PollListLoading && state is! PollListSuccess)
+                  const Padding(
+                    padding: EdgeInsets.all(AppSpacing.spaceLG),
+                    child: Center(child: CircularProgressIndicator()),
+                  )
+                else if (state is PollListSuccess)
+                  _buildPollList(context, state.polls)
+                else if (state is PollListError)
+                  _buildErrorState(context, state.message)
+                else
+                  _buildEmptyState(),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildPollList(BuildContext context, List<PollResponse> polls) {
+    if (polls.isEmpty) {
+      return _buildEmptyState();
+    }
+
+    // Filter only active polls for users
+    final activePolls = polls.where((poll) {
+      final now = DateTime.now();
+      return !poll.isDelete &&
+          now.isAfter(poll.startTime) &&
+          now.isBefore(poll.endTime);
+    }).toList();
+
+    if (activePolls.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(AppSpacing.spaceLG),
+        child: Center(
+          child: Column(
+            children: [
+              const Icon(
+                Icons.poll_outlined,
+                size: 48,
+                color: AppColors.coolGray500,
+              ),
+              const SizedBox(height: AppSpacing.spaceMD),
+              Text(
+                'Chưa có poll nào đang diễn ra',
+                style: AppTextStyles.bodyMedium,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () async {
+        context.read<PollListBloc>().add(PollListRefreshed(eventId));
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      },
+      child: ListView.separated(
+        shrinkWrap: true,
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: activePolls.length,
+        separatorBuilder: (context, index) => const SizedBox(height: 12),
+        itemBuilder: (context, index) {
+          final poll = activePolls[index];
+          return _UserPollCard(
+            poll: poll,
+            isUserRegistered: isUserRegistered,
+            onVote: () {
+              if (!isUserRegistered) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text(
+                      'Bạn cần tham gia sự kiện trước khi bỏ phiếu',
+                    ),
+                    backgroundColor: AppColors.red500,
+                    behavior: SnackBarBehavior.floating,
+                  ),
+                );
+                return;
+              }
+              context
+                  .pushNamed(
+                    AppRoutes.votePoll,
+                    pathParameters: {'id': poll.id.toString()},
+                  )
+                  .then((result) {
+                    if (result == true) {
+                      context.read<PollListBloc>().add(
+                        PollListRefreshed(eventId),
+                      );
+                    }
+                  });
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.spaceLG),
+      child: Center(
+        child: Column(
+          children: [
+            const Icon(
+              Icons.poll_outlined,
+              size: 48,
+              color: AppColors.coolGray500,
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            Text('Chưa có poll nào', style: AppTextStyles.bodyMedium),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context, String message) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.spaceLG),
+      child: Center(
+        child: Column(
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: AppColors.red500),
+            const SizedBox(height: AppSpacing.spaceMD),
+            Text(
+              'Không thể tải danh sách polls',
+              style: AppTextStyles.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.spaceXS),
+            Text(
+              message,
+              style: AppTextStyles.bodySmall.copyWith(
+                color: AppColors.coolGray500,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            ElevatedButton(
+              onPressed: () {
+                context.read<PollListBloc>().add(PollListFetched(eventId));
+              },
+              child: const Text('Thử lại'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Card hiển thị poll cho người dùng thường
+class _UserPollCard extends StatelessWidget {
+  const _UserPollCard({
+    required this.poll,
+    required this.isUserRegistered,
+    required this.onVote,
+  });
+
+  final PollResponse poll;
+  final bool isUserRegistered;
+  final VoidCallback onVote;
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final isPollActive =
+        !poll.isDelete &&
+        now.isAfter(poll.startTime) &&
+        now.isBefore(poll.endTime);
+    final canVote = isPollActive && !poll.hasVoted && isUserRegistered;
+
+    return InkWell(
+      onTap: canVote ? onVote : null,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(AppSpacing.spaceMD),
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: canVote
+              ? Border.all(
+                  color: AppColors.vkuBlue.withValues(alpha: 0.3),
+                  width: 2,
+                )
+              : Border.all(color: AppColors.border, width: 1.5),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.coolGray900.withValues(alpha: 0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: AppColors.amber100,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Icon(
+                    Icons.poll_rounded,
+                    color: AppColors.amber600,
+                    size: 20,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.spaceMD),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        poll.title,
+                        style: AppTextStyles.heading5.copyWith(
+                          color: canVote
+                              ? AppColors.vkuBlue
+                              : AppColors.coolGray900,
+                          fontWeight: canVote
+                              ? FontWeight.w600
+                              : FontWeight.normal,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.circle,
+                            size: 8,
+                            color: canVote
+                                ? AppColors.green500
+                                : AppColors.coolGray500,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            poll.pollType.label,
+                            style: AppTextStyles.bodySmall.copyWith(
+                              color: AppColors.coolGray500,
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.spaceMD),
+                          Text(
+                            '${poll.options.length} lựa chọn',
+                            style: AppTextStyles.bodySmall.copyWith(
+                              color: AppColors.coolGray500,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.spaceMD),
+            if (canVote)
+              SizedBox(
+                width: double.infinity,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.spaceMD,
+                    vertical: AppSpacing.spaceMD,
+                  ),
+                  decoration: BoxDecoration(
+                    gradient: AppColors.primaryGradient,
+                    borderRadius: BorderRadius.circular(12),
+                    boxShadow: [
+                      BoxShadow(
+                        color: AppColors.vkuBlue.withValues(alpha: 0.3),
+                        blurRadius: 8,
+                        offset: const Offset(0, 4),
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(
+                        Icons.how_to_vote_rounded,
+                        color: AppColors.white,
+                        size: 20,
+                      ),
+                      const SizedBox(width: AppSpacing.spaceXM),
+                      Text(
+                        'Bỏ phiếu ngay',
+                        style: AppTextStyles.heading5.copyWith(
+                          color: AppColors.white,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else if (!isUserRegistered && isPollActive)
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.spaceMD,
+                  vertical: AppSpacing.spaceMD,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.amber100,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: AppColors.amber400, width: 1.5),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.info_outline_rounded,
+                      color: AppColors.amber600,
+                      size: 20,
+                    ),
+                    const SizedBox(width: AppSpacing.spaceXM),
+                    Expanded(
+                      child: Text(
+                        'Tham gia sự kiện để bỏ phiếu',
+                        style: AppTextStyles.bodySmall.copyWith(
+                          color: AppColors.amber800,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            else if (poll.hasVoted)
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.spaceMD,
+                  vertical: AppSpacing.spaceMD,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.green50,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: AppColors.green500, width: 1.5),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.check_circle_rounded,
+                      color: AppColors.green500,
+                      size: 20,
+                    ),
+                    const SizedBox(width: AppSpacing.spaceXM),
+                    Text(
+                      'Đã bỏ phiếu',
+                      style: AppTextStyles.heading5.copyWith(
+                        color: AppColors.green800,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/poll/presentation/widgets/vote_poll/poll_option_card.dart
+++ b/lib/features/poll/presentation/widgets/vote_poll/poll_option_card.dart
@@ -1,0 +1,109 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/features/poll/data/models/option_response.dart';
+import 'package:event_management/features/poll/domain/entities/poll_type.dart';
+import 'package:flutter/material.dart';
+
+/// Widget hiển thị một option trong poll với design đẹp
+class PollOptionCard extends StatelessWidget {
+  const PollOptionCard({
+    required this.option,
+    required this.isSelected,
+    required this.pollType,
+    required this.onTap,
+    super.key,
+  });
+
+  final OptionResponse option;
+  final bool isSelected;
+  final PollType pollType;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+        padding: const EdgeInsets.all(AppSpacing.spaceMD),
+        decoration: BoxDecoration(
+          color: isSelected ? AppColors.blue50 : AppColors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: isSelected ? AppColors.vkuBlue : AppColors.border,
+            width: isSelected ? 2.5 : 1.5,
+          ),
+          boxShadow: isSelected
+              ? [
+                  BoxShadow(
+                    color: AppColors.vkuBlue.withValues(alpha: 0.2),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ]
+              : [
+                  BoxShadow(
+                    color: AppColors.coolGray900.withValues(alpha: 0.05),
+                    blurRadius: 4,
+                    offset: const Offset(0, 1),
+                  ),
+                ],
+        ),
+        child: Row(
+          children: [
+            // Selection indicator
+            Container(
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                shape: pollType == PollType.singleChoice
+                    ? BoxShape.circle
+                    : BoxShape.rectangle,
+                borderRadius: pollType == PollType.singleChoice
+                    ? null
+                    : BorderRadius.circular(6),
+                border: Border.all(
+                  color: isSelected ? AppColors.vkuBlue : AppColors.coolGray500,
+                  width: 2,
+                ),
+                color: isSelected ? AppColors.vkuBlue : Colors.transparent,
+              ),
+              child: isSelected
+                  ? Icon(
+                      pollType == PollType.singleChoice
+                          ? Icons.check_rounded
+                          : Icons.check_rounded,
+                      color: AppColors.white,
+                      size: 16,
+                    )
+                  : null,
+            ),
+            const SizedBox(width: AppSpacing.spaceMD),
+
+            // Option text
+            Expanded(
+              child: Text(
+                option.text,
+                style: AppTextStyles.bodyMedium.copyWith(
+                  color: isSelected ? AppColors.vkuBlue : AppColors.coolGray900,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                ),
+              ),
+            ),
+
+            // Selected indicator icon
+            if (isSelected)
+              const Icon(
+                Icons.arrow_forward_ios_rounded,
+                color: AppColors.vkuBlue,
+                size: 16,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Thêm màn hình thăm dò ý kiến ​​với giao diện người dùng (UI) để người dùng bỏ phiếu
- Thêm VotePollBloc để quản lý trạng thái thăm dò ý kiến
- Thêm điểm cuối API thăm dò ý kiến ​​và phương thức kho lưu trữ
- Thêm API MyVotedOptions để tìm các tùy chọn đã bỏ phiếu của người dùng
- Cập nhật danh sách thăm dò ý kiến ​​để hiển thị nút bỏ phiếu cho người dùng
- Thêm tiện ích thẻ tùy chọn thăm dò ý kiến ​​để bỏ phiếu
- Xử lý phản hồi thăm dò ý kiến ​​(MessageResponse) và tìm các thăm dò ý kiến ​​đã cập nhật
- Khắc phục sự cố giao diện người dùng với tiêu đề SliverAppBar chồng chéo
- Xử lý trạng thái tải khi người dùng đã bỏ phiếu