### PR TITLE
fix: sửa lỗi edit/delete sub unit và overflow event card

### DIFF
--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -35,6 +35,8 @@ import 'package:event_management/features/poll/presentation/bloc/vote_poll/vote_
 import 'package:event_management/features/unit/data/datasource/unit_api_client.dart';
 import 'package:event_management/features/unit/data/repository/unit_repository_impl.dart';
 import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_bloc.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_bloc.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get_it/get_it.dart';
 
@@ -96,6 +98,9 @@ Future<void> init() async {
     ..registerFactory(() => PollStatsBloc(sl<PollRepository>()))
     ..registerFactory(() => UpdatePollBloc(sl<PollRepository>()))
     ..registerFactory(() => VotePollBloc(sl<PollRepository>()))
+    // Unit Bloc
+    ..registerFactory(() => UnitListBloc(sl<UnitRepository>()))
+    ..registerFactory(() => UnitFormBloc(sl<UnitRepository>()))
     // Dio instances - Main Dio for general use (has auth interceptor)
     ..registerLazySingleton<Dio>(
       () =>

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -20,6 +20,11 @@ import 'package:event_management/features/event/event_list/presentation/bloc/eve
 import 'package:event_management/features/event/event_list/presentation/pages/event_list_screen.dart';
 import 'package:event_management/features/event/event_management/presentation/pages/event_management_screen.dart';
 import 'package:event_management/features/poll/presentation/pages/vote_poll_screen.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_bloc.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_event.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_bloc.dart';
+import 'package:event_management/features/unit/presentation/pages/unit_form_screen.dart';
+import 'package:event_management/features/unit/presentation/pages/unit_list_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -38,6 +43,9 @@ class AppRoutes {
   static const String eventManagement = '/events/:id/manage';
   static const String adminEditEvent = '/admin/events/:id/edit';
   static const String votePoll = '/polls/:id/vote';
+  static const String unitList = '/units';
+  static const String unitForm = '/units/form';
+  static const String unitFormEdit = '/units/form/:id';
 }
 
 final GoRouter appRouter = GoRouter(
@@ -189,6 +197,38 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) {
         final pollId = int.parse(state.pathParameters['id']!);
         return VotePollScreen(pollId: pollId);
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.unitList,
+      name: AppRoutes.unitList,
+      builder: (context, state) {
+        return BlocProvider(
+          create: (context) => sl<UnitListBloc>(),
+          child: const UnitListScreen(),
+        );
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.unitForm,
+      name: AppRoutes.unitForm,
+      builder: (context, state) {
+        return BlocProvider(
+          create: (context) => sl<UnitFormBloc>(),
+          child: const UnitFormScreen(),
+        );
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.unitFormEdit,
+      name: AppRoutes.unitFormEdit,
+      builder: (context, state) {
+        final unitId = int.parse(state.pathParameters['id']!);
+        return BlocProvider(
+          create: (context) =>
+              sl<UnitFormBloc>()..add(UnitFormInitialized(unitId)),
+          child: UnitFormScreen(unitId: unitId),
+        );
       },
     ),
   ],

--- a/lib/features/admin/data/models/user_response_dto.dart
+++ b/lib/features/admin/data/models/user_response_dto.dart
@@ -79,7 +79,7 @@ class UserResponseDto {
       email: dto.email,
       phoneNumber: dto.phoneNumber,
       enabled: dto.enabled,
-      unit: dto.unit != null ? UnitResponseDto.toEntity(dto.unit!) : null,
+      unit: dto.unit?.toEntity(),
       roles: dto.roles?.map(RoleDto.toEntity).toList(),
     );
   }

--- a/lib/features/admin/presentation/pages/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/pages/admin_dashboard_screen.dart
@@ -2,18 +2,22 @@ import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
 import 'package:event_management/core/config/app_text_styles.dart';
 import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/core/widgets/user_menu.dart';
 import 'package:event_management/features/admin/presentation/bloc/user_management/user_management_bloc.dart';
 import 'package:event_management/features/admin/presentation/pages/user_management_screen.dart';
 import 'package:event_management/features/admin/presentation/widgets/admin_event_filter_chips.dart';
 import 'package:event_management/features/admin/presentation/widgets/admin_event_search_bar.dart';
 import 'package:event_management/features/admin/presentation/widgets/admin_stat_card.dart';
 import 'package:event_management/features/admin/presentation/widgets/event_list_grid_admin.dart';
+import 'package:event_management/features/auth/domain/repositories/auth_repository.dart';
 import 'package:event_management/features/event/event_list/presentation/bloc/event_list_bloc.dart';
 import 'package:event_management/features/event/event_list/presentation/bloc/event_list_event.dart';
 import 'package:event_management/features/event/event_list/presentation/bloc/event_list_state.dart';
 import 'package:event_management/features/event/shared/data/models/event.dart';
 import 'package:event_management/features/event/shared/data/models/event_counters.dart';
 import 'package:event_management/features/event/shared/data/models/event_status.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_bloc.dart';
+import 'package:event_management/features/unit/presentation/pages/unit_list_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -136,14 +140,7 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
                       ],
                     ),
                   ),
-                  IconButton(
-                    onPressed: () {},
-                    icon: const Icon(
-                      Icons.account_circle_rounded,
-                      color: AppColors.white,
-                      size: 32,
-                    ),
-                  ),
+                  UserMenu(authRepository: di.sl<AuthRepository>()),
                 ],
               ),
               const SizedBox(height: 16),
@@ -446,32 +443,9 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen>
   }
 
   Widget _buildUnitManagementTab() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.business_rounded,
-            size: 80,
-            color: AppColors.coolGray500.withOpacity(0.5),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Quản lý đơn vị',
-            style: AppTextStyles.heading3.copyWith(
-              color: AppColors.coolGray700,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Chức năng đang được phát triển',
-            style: AppTextStyles.bodyMedium.copyWith(
-              color: AppColors.coolGray500,
-            ),
-          ),
-        ],
-      ),
+    return BlocProvider(
+      create: (context) => di.sl<UnitListBloc>(),
+      child: const UnitListScreen(showAppBar: false),
     );
   }
 }

--- a/lib/features/admin/presentation/widgets/event_card_admin.dart
+++ b/lib/features/admin/presentation/widgets/event_card_admin.dart
@@ -4,10 +4,10 @@ import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
 import 'package:event_management/core/config/app_text_styles.dart';
 import 'package:event_management/core/utils/date_time_formatter.dart';
-import 'package:event_management/features/event/shared/data/models/event.dart';
 import 'package:event_management/features/event/event_list/presentation/widgets/event_card/event_card_banner.dart';
 import 'package:event_management/features/event/event_list/presentation/widgets/event_card/event_info_row.dart';
 import 'package:event_management/features/event/event_list/presentation/widgets/event_card/event_participants_row.dart';
+import 'package:event_management/features/event/shared/data/models/event.dart';
 import 'package:flutter/material.dart';
 
 class EventCardAdmin extends StatefulWidget {
@@ -188,10 +188,9 @@ class _EventCardAdminState extends State<EventCardAdmin>
                     borderRadius: BorderRadius.circular(16),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
                       children: [
                         EventCardBanner(event: widget.event),
-                        Flexible(
+                        Expanded(
                           child: Padding(
                             padding: const EdgeInsets.fromLTRB(
                               AppSpacing.spaceMD,
@@ -199,49 +198,53 @@ class _EventCardAdminState extends State<EventCardAdmin>
                               AppSpacing.spaceMD,
                               AppSpacing.spaceXM,
                             ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                // Event info
-                                EventInfoRow(
-                                  icon: Icons.access_time_rounded,
-                                  text:
-                                      DateTimeFormatter.formatDateTimeWithTime(
-                                        widget.event.startTime,
-                                      ),
-                                  iconColor: AppColors.vkuBlue,
-                                ),
-                                if (widget.event.location != null) ...[
-                                  const SizedBox(height: AppSpacing.spaceXS),
+                            child: SingleChildScrollView(
+                              physics: const BouncingScrollPhysics(),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  // Event info
                                   EventInfoRow(
-                                    icon: Icons.location_on_rounded,
-                                    text: widget.event.location!,
-                                    iconColor: AppColors.green500,
-                                  ),
-                                ],
-                                if (widget.event.maxParticipants != null) ...[
-                                  const SizedBox(height: AppSpacing.spaceXS),
-                                  EventParticipantsRow(
-                                    currentParticipants:
-                                        widget.event.currentParticipants,
-                                    maxParticipants:
-                                        widget.event.maxParticipants,
-                                  ),
-                                ],
-                                // Admin info section - Only show if space allows
-                                if (widget.event.createdByName != null) ...[
-                                  const SizedBox(height: AppSpacing.spaceXS),
-                                  EventInfoRow(
-                                    icon: Icons.person_rounded,
+                                    icon: Icons.access_time_rounded,
                                     text:
-                                        widget.event.createdByName!.length > 20
-                                        ? 'Tạo bởi: ${widget.event.createdByName!.substring(0, 20)}...'
-                                        : 'Tạo bởi: ${widget.event.createdByName}',
-                                    iconColor: AppColors.coolGray700,
+                                        DateTimeFormatter.formatDateTimeWithTime(
+                                          widget.event.startTime,
+                                        ),
+                                    iconColor: AppColors.vkuBlue,
                                   ),
+                                  if (widget.event.location != null) ...[
+                                    const SizedBox(height: AppSpacing.spaceXS),
+                                    EventInfoRow(
+                                      icon: Icons.location_on_rounded,
+                                      text: widget.event.location!,
+                                      iconColor: AppColors.green500,
+                                    ),
+                                  ],
+                                  if (widget.event.maxParticipants != null) ...[
+                                    const SizedBox(height: AppSpacing.spaceXS),
+                                    EventParticipantsRow(
+                                      currentParticipants:
+                                          widget.event.currentParticipants,
+                                      maxParticipants:
+                                          widget.event.maxParticipants,
+                                    ),
+                                  ],
+                                  // Admin info section - Only show if space allows
+                                  if (widget.event.createdByName != null) ...[
+                                    const SizedBox(height: AppSpacing.spaceXS),
+                                    EventInfoRow(
+                                      icon: Icons.person_rounded,
+                                      text:
+                                          widget.event.createdByName!.length >
+                                              20
+                                          ? 'Tạo bởi: ${widget.event.createdByName!.substring(0, 20)}...'
+                                          : 'Tạo bởi: ${widget.event.createdByName}',
+                                      iconColor: AppColors.coolGray700,
+                                    ),
+                                  ],
                                 ],
-                              ],
+                              ),
                             ),
                           ),
                         ),

--- a/lib/features/auth/presentation/bloc/register/register_bloc.dart
+++ b/lib/features/auth/presentation/bloc/register/register_bloc.dart
@@ -49,7 +49,7 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     Emitter<RegisterState> emit,
   ) async {
     emit(RegisterLoading());
-    final result = await _unitRepository.getUnits(0, 1000);
+    final result = await _unitRepository.getAllUnits();
 
     final accountTypes = result.where((u) => u.parentId == null).toList();
 

--- a/lib/features/unit/data/datasource/unit_api_client.dart
+++ b/lib/features/unit/data/datasource/unit_api_client.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
-import 'package:event_management/features/unit/data/model/unit_page_response_dto.dart';
+import 'package:event_management/features/unit/data/model/page_response.dart';
+import 'package:event_management/features/unit/data/model/unit_request_dto.dart';
+import 'package:event_management/features/unit/data/model/unit_response_dto.dart';
 import 'package:injectable/injectable.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -12,8 +14,27 @@ abstract class UnitApiClient {
   factory UnitApiClient(Dio dio) = _UnitApiClient;
 
   @GET('/units')
-  Future<UnitPageResponseDto> getUnits({
+  Future<PageResponse<UnitResponseDto>> listUnits({
+    @Query('q') String? query,
     @Query('page') int page = 0,
-    @Query('size') int size = 1000,
+    @Query('size') int size = 20,
   });
+
+  @GET('/units/all')
+  Future<List<UnitResponseDto>> getAllUnits();
+
+  @GET('/units/{id}')
+  Future<UnitResponseDto> getUnit(@Path('id') int id);
+
+  @POST('/units')
+  Future<UnitResponseDto> createUnit(@Body() UnitRequestDto dto);
+
+  @PUT('/units/{id}')
+  Future<UnitResponseDto> updateUnit(
+    @Path('id') int id,
+    @Body() UnitRequestDto dto,
+  );
+
+  @DELETE('/units/{id}')
+  Future<void> deleteUnit(@Path('id') int id);
 }

--- a/lib/features/unit/data/datasource/unit_api_client.g.dart
+++ b/lib/features/unit/data/datasource/unit_api_client.g.dart
@@ -20,12 +20,21 @@ class _UnitApiClient implements UnitApiClient {
   final ParseErrorLogger? errorLogger;
 
   @override
-  Future<UnitPageResponseDto> getUnits({int page = 0, int size = 1000}) async {
+  Future<PageResponse<UnitResponseDto>> listUnits({
+    String? query,
+    int page = 0,
+    int size = 20,
+  }) async {
     final _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{r'page': page, r'size': size};
+    final queryParameters = <String, dynamic>{
+      r'q': query,
+      r'page': page,
+      r'size': size,
+    };
+    queryParameters.removeWhere((k, v) => v == null);
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
-    final _options = _setStreamType<UnitPageResponseDto>(
+    final _options = _setStreamType<PageResponse<UnitResponseDto>>(
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
@@ -36,14 +45,150 @@ class _UnitApiClient implements UnitApiClient {
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late UnitPageResponseDto _value;
+    late PageResponse<UnitResponseDto> _value;
     try {
-      _value = UnitPageResponseDto.fromJson(_result.data!);
+      _value = PageResponse<UnitResponseDto>.fromJson(
+        _result.data!,
+        (json) => UnitResponseDto.fromJson(json as Map<String, dynamic>),
+      );
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
+  }
+
+  @override
+  Future<List<UnitResponseDto>> getAllUnits() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<UnitResponseDto>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/units/all',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<UnitResponseDto> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) => UnitResponseDto.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<UnitResponseDto> getUnit(int id) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<UnitResponseDto>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/units/${id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late UnitResponseDto _value;
+    try {
+      _value = UnitResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<UnitResponseDto> createUnit(UnitRequestDto dto) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(dto.toJson());
+    final _options = _setStreamType<UnitResponseDto>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/units',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late UnitResponseDto _value;
+    try {
+      _value = UnitResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<UnitResponseDto> updateUnit(int id, UnitRequestDto dto) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(dto.toJson());
+    final _options = _setStreamType<UnitResponseDto>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/units/${id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late UnitResponseDto _value;
+    try {
+      _value = UnitResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<void> deleteUnit(int id) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/units/${id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
   }
 
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {

--- a/lib/features/unit/data/model/page_response.dart
+++ b/lib/features/unit/data/model/page_response.dart
@@ -1,0 +1,62 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'page_response.g.dart';
+
+/// Generic PageResponse model cho pagination
+@JsonSerializable(genericArgumentFactories: true)
+class PageResponse<T> {
+  const PageResponse({
+    required this.content,
+    required this.page,
+    required this.size,
+    required this.totalElements,
+    required this.totalPages,
+    required this.first,
+    required this.last,
+    required this.hasNext,
+    required this.hasPrevious,
+    required this.numberOfElements,
+    required this.empty,
+  });
+
+  factory PageResponse.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object? json) fromJsonT,
+  ) => _$PageResponseFromJson(json, fromJsonT);
+
+  @JsonKey(name: 'content')
+  final List<T> content;
+
+  @JsonKey(name: 'page')
+  final int page;
+
+  @JsonKey(name: 'size')
+  final int size;
+
+  @JsonKey(name: 'total_elements')
+  final int totalElements;
+
+  @JsonKey(name: 'total_pages')
+  final int totalPages;
+
+  @JsonKey(name: 'first')
+  final bool first;
+
+  @JsonKey(name: 'last')
+  final bool last;
+
+  @JsonKey(name: 'has_next')
+  final bool hasNext;
+
+  @JsonKey(name: 'has_previous')
+  final bool hasPrevious;
+
+  @JsonKey(name: 'number_of_elements')
+  final int numberOfElements;
+
+  @JsonKey(name: 'empty')
+  final bool empty;
+
+  Map<String, dynamic> toJson(Object? Function(T value) toJsonT) =>
+      _$PageResponseToJson(this, toJsonT);
+}

--- a/lib/features/unit/data/model/page_response.g.dart
+++ b/lib/features/unit/data/model/page_response.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'page_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PageResponse<T> _$PageResponseFromJson<T>(
+  Map<String, dynamic> json,
+  T Function(Object? json) fromJsonT,
+) => PageResponse<T>(
+  content: (json['content'] as List<dynamic>).map(fromJsonT).toList(),
+  page: (json['page'] as num).toInt(),
+  size: (json['size'] as num).toInt(),
+  totalElements: (json['total_elements'] as num).toInt(),
+  totalPages: (json['total_pages'] as num).toInt(),
+  first: json['first'] as bool,
+  last: json['last'] as bool,
+  hasNext: json['has_next'] as bool,
+  hasPrevious: json['has_previous'] as bool,
+  numberOfElements: (json['number_of_elements'] as num).toInt(),
+  empty: json['empty'] as bool,
+);
+
+Map<String, dynamic> _$PageResponseToJson<T>(
+  PageResponse<T> instance,
+  Object? Function(T value) toJsonT,
+) => <String, dynamic>{
+  'content': instance.content.map(toJsonT).toList(),
+  'page': instance.page,
+  'size': instance.size,
+  'total_elements': instance.totalElements,
+  'total_pages': instance.totalPages,
+  'first': instance.first,
+  'last': instance.last,
+  'has_next': instance.hasNext,
+  'has_previous': instance.hasPrevious,
+  'number_of_elements': instance.numberOfElements,
+  'empty': instance.empty,
+};

--- a/lib/features/unit/data/model/unit_request_dto.dart
+++ b/lib/features/unit/data/model/unit_request_dto.dart
@@ -1,0 +1,29 @@
+import 'package:event_management/features/unit/data/model/unit_type_converter.dart';
+import 'package:event_management/features/unit/domain/entities/unit_type.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'unit_request_dto.g.dart';
+
+@JsonSerializable()
+class UnitRequestDto {
+  const UnitRequestDto({
+    required this.unitName,
+    required this.unitType,
+    this.parentId,
+  });
+
+  factory UnitRequestDto.fromJson(Map<String, dynamic> json) =>
+      _$UnitRequestDtoFromJson(json);
+
+  @JsonKey(name: 'unit_name')
+  final String unitName;
+
+  @JsonKey(name: 'unit_type')
+  @UnitTypeConverter()
+  final UnitType unitType;
+
+  @JsonKey(name: 'parent_id')
+  final int? parentId;
+
+  Map<String, dynamic> toJson() => _$UnitRequestDtoToJson(this);
+}

--- a/lib/features/unit/data/model/unit_request_dto.g.dart
+++ b/lib/features/unit/data/model/unit_request_dto.g.dart
@@ -1,25 +1,21 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'unit_response_dto.dart';
+part of 'unit_request_dto.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-UnitResponseDto _$UnitResponseDtoFromJson(Map<String, dynamic> json) =>
-    UnitResponseDto(
-      id: (json['id'] as num).toInt(),
+UnitRequestDto _$UnitRequestDtoFromJson(Map<String, dynamic> json) =>
+    UnitRequestDto(
       unitName: json['unit_name'] as String,
       unitType: const UnitTypeConverter().fromJson(json['unit_type'] as String),
       parentId: (json['parent_id'] as num?)?.toInt(),
-      parentName: json['parent_name'] as String?,
     );
 
-Map<String, dynamic> _$UnitResponseDtoToJson(UnitResponseDto instance) =>
+Map<String, dynamic> _$UnitRequestDtoToJson(UnitRequestDto instance) =>
     <String, dynamic>{
-      'id': instance.id,
       'unit_name': instance.unitName,
       'unit_type': const UnitTypeConverter().toJson(instance.unitType),
       'parent_id': instance.parentId,
-      'parent_name': instance.parentName,
     };

--- a/lib/features/unit/data/model/unit_response_dto.dart
+++ b/lib/features/unit/data/model/unit_response_dto.dart
@@ -1,3 +1,5 @@
+import 'package:event_management/features/unit/data/model/unit_type_converter.dart';
+import 'package:event_management/features/unit/domain/entities/unit_type.dart';
 import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -5,7 +7,7 @@ part 'unit_response_dto.g.dart';
 
 @JsonSerializable()
 class UnitResponseDto {
-  UnitResponseDto({
+  const UnitResponseDto({
     required this.id,
     required this.unitName,
     required this.unitType,
@@ -23,7 +25,8 @@ class UnitResponseDto {
   final String unitName;
 
   @JsonKey(name: 'unit_type')
-  final String unitType;
+  @UnitTypeConverter()
+  final UnitType unitType;
 
   @JsonKey(name: 'parent_id')
   final int? parentId;
@@ -33,17 +36,21 @@ class UnitResponseDto {
 
   Map<String, dynamic> toJson() => _$UnitResponseDtoToJson(this);
 
-  static UnitEntity toEntity(UnitResponseDto dto) {
+  UnitEntity toEntity() {
     return UnitEntity(
-      id: dto.id,
-      unitName: dto.unitName,
-      unitType: dto.unitType,
-      parentId: dto.parentId,
-      parentName: dto.parentName,
+      id: id,
+      unitName: unitName,
+      unitType: unitType,
+      parentId: parentId,
+      parentName: parentName,
     );
   }
 
+  static UnitEntity toEntityStatic(UnitResponseDto dto) {
+    return dto.toEntity();
+  }
+
   static List<UnitEntity> toEntities(List<UnitResponseDto> dtoList) {
-    return dtoList.map(UnitResponseDto.toEntity).toList();
+    return dtoList.map((dto) => dto.toEntity()).toList();
   }
 }

--- a/lib/features/unit/data/model/unit_type_converter.dart
+++ b/lib/features/unit/data/model/unit_type_converter.dart
@@ -1,0 +1,26 @@
+import 'package:event_management/features/unit/domain/entities/unit_type.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+/// Converter để serialize/deserialize UnitType enum
+class UnitTypeConverter implements JsonConverter<UnitType, String> {
+  const UnitTypeConverter();
+
+  @override
+  UnitType fromJson(String json) {
+    switch (json.toUpperCase()) {
+      case 'DEPARTMENT':
+        return UnitType.department;
+      case 'STUDENT':
+        return UnitType.student;
+      case 'EXTERNAL':
+        return UnitType.external;
+      default:
+        return UnitType.department;
+    }
+  }
+
+  @override
+  String toJson(UnitType object) {
+    return object.value;
+  }
+}

--- a/lib/features/unit/data/repository/unit_repository_impl.dart
+++ b/lib/features/unit/data/repository/unit_repository_impl.dart
@@ -1,17 +1,129 @@
+import 'package:dio/dio.dart';
 import 'package:event_management/features/unit/data/datasource/unit_api_client.dart';
-import 'package:event_management/features/unit/data/model/unit_response_dto.dart';
+import 'package:event_management/features/unit/data/model/page_response.dart';
+import 'package:event_management/features/unit/data/model/unit_request_dto.dart';
 import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
 import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
 import 'package:injectable/injectable.dart';
 
 @LazySingleton(as: UnitRepository)
 class UnitRepositoryImpl implements UnitRepository {
-  UnitRepositoryImpl(this._apiClient);
+  const UnitRepositoryImpl(this._apiClient);
+
   final UnitApiClient _apiClient;
 
   @override
-  Future<List<UnitEntity>> getUnits(int page, int size) async {
-    final response = await _apiClient.getUnits(page: page, size: size);
-    return UnitResponseDto.toEntities(response.content);
+  Future<PageResponse<UnitEntity>> listUnits({
+    String? query,
+    int page = 0,
+    int size = 20,
+  }) async {
+    try {
+      final response = await _apiClient.listUnits(
+        query: query,
+        page: page,
+        size: size,
+      );
+      return PageResponse<UnitEntity>(
+        content: response.content.map((dto) => dto.toEntity()).toList(),
+        page: response.page,
+        size: response.size,
+        totalElements: response.totalElements,
+        totalPages: response.totalPages,
+        first: response.first,
+        last: response.last,
+        hasNext: response.hasNext,
+        hasPrevious: response.hasPrevious,
+        numberOfElements: response.numberOfElements,
+        empty: response.empty,
+      );
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể lấy danh sách đơn vị.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<List<UnitEntity>> getAllUnits() async {
+    try {
+      final response = await _apiClient.getAllUnits();
+      return response.map((dto) => dto.toEntity()).toList();
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể lấy danh sách đơn vị.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<UnitEntity> getUnit(int id) async {
+    try {
+      final response = await _apiClient.getUnit(id);
+      return response.toEntity();
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể lấy thông tin đơn vị.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<UnitEntity> createUnit(UnitRequestDto dto) async {
+    try {
+      final response = await _apiClient.createUnit(dto);
+      return response.toEntity();
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể tạo đơn vị.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<UnitEntity> updateUnit(int id, UnitRequestDto dto) async {
+    try {
+      final response = await _apiClient.updateUnit(id, dto);
+      return response.toEntity();
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể cập nhật đơn vị.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<void> deleteUnit(int id) async {
+    try {
+      await _apiClient.deleteUnit(id);
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể xóa đơn vị.');
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
   }
 }

--- a/lib/features/unit/domain/entities/unit_type.dart
+++ b/lib/features/unit/domain/entities/unit_type.dart
@@ -1,0 +1,22 @@
+/// Loại đơn vị
+enum UnitType {
+  department('DEPARTMENT', 'Phòng ban'),
+  student('STUDENT', 'Sinh viên'),
+  external('EXTERNAL', 'Bên ngoài');
+
+  const UnitType(this.value, this.label);
+
+  final String value;
+  final String label;
+
+  static UnitType? fromString(String? value) {
+    if (value == null) return null;
+    try {
+      return UnitType.values.firstWhere(
+        (type) => type.value == value.toUpperCase(),
+      );
+    } catch (e) {
+      return UnitType.department;
+    }
+  }
+}

--- a/lib/features/unit/domain/entity/unit_entity.dart
+++ b/lib/features/unit/domain/entity/unit_entity.dart
@@ -1,5 +1,8 @@
-class UnitEntity {
-  UnitEntity({
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/unit/domain/entities/unit_type.dart';
+
+class UnitEntity extends Equatable {
+  const UnitEntity({
     required this.id,
     required this.unitName,
     required this.unitType,
@@ -9,7 +12,26 @@ class UnitEntity {
 
   final int id;
   final String unitName;
-  final String unitType;
+  final UnitType unitType;
   final int? parentId;
   final String? parentName;
+
+  @override
+  List<Object?> get props => [id, unitName, unitType, parentId, parentName];
+
+  UnitEntity copyWith({
+    int? id,
+    String? unitName,
+    UnitType? unitType,
+    int? parentId,
+    String? parentName,
+  }) {
+    return UnitEntity(
+      id: id ?? this.id,
+      unitName: unitName ?? this.unitName,
+      unitType: unitType ?? this.unitType,
+      parentId: parentId ?? this.parentId,
+      parentName: parentName ?? this.parentName,
+    );
+  }
 }

--- a/lib/features/unit/domain/repository/unit_repository.dart
+++ b/lib/features/unit/domain/repository/unit_repository.dart
@@ -1,5 +1,21 @@
+import 'package:event_management/features/unit/data/model/page_response.dart';
+import 'package:event_management/features/unit/data/model/unit_request_dto.dart';
 import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
 
 abstract class UnitRepository {
-  Future<List<UnitEntity>> getUnits(int page, int size);
+  Future<PageResponse<UnitEntity>> listUnits({
+    String? query,
+    int page = 0,
+    int size = 20,
+  });
+
+  Future<List<UnitEntity>> getAllUnits();
+
+  Future<UnitEntity> getUnit(int id);
+
+  Future<UnitEntity> createUnit(UnitRequestDto dto);
+
+  Future<UnitEntity> updateUnit(int id, UnitRequestDto dto);
+
+  Future<void> deleteUnit(int id);
 }

--- a/lib/features/unit/presentation/bloc/unit_form/unit_form_bloc.dart
+++ b/lib/features/unit/presentation/bloc/unit_form/unit_form_bloc.dart
@@ -1,0 +1,54 @@
+import 'package:bloc/bloc.dart';
+import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_event.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_state.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class UnitFormBloc extends Bloc<UnitFormEvent, UnitFormState> {
+  UnitFormBloc(this._unitRepository) : super(const UnitFormInitial()) {
+    on<UnitFormInitialized>(_onInitialized);
+    on<UnitFormSubmitted>(_onSubmitted);
+    on<UnitFormReset>(_onReset);
+  }
+
+  final UnitRepository _unitRepository;
+
+  Future<void> _onInitialized(
+    UnitFormInitialized event,
+    Emitter<UnitFormState> emit,
+  ) async {
+    if (event.unitId == null) {
+      return;
+    }
+
+    emit(const UnitFormLoading());
+
+    try {
+      final unit = await _unitRepository.getUnit(event.unitId!);
+      emit(UnitFormLoadSuccess(unit));
+    } catch (e) {
+      emit(UnitFormError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onSubmitted(
+    UnitFormSubmitted event,
+    Emitter<UnitFormState> emit,
+  ) async {
+    emit(const UnitFormLoading());
+
+    try {
+      final unit = event.unitId == null
+          ? await _unitRepository.createUnit(event.dto)
+          : await _unitRepository.updateUnit(event.unitId!, event.dto);
+      emit(UnitFormSuccess(unit));
+    } catch (e) {
+      emit(UnitFormError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  void _onReset(UnitFormReset event, Emitter<UnitFormState> emit) {
+    emit(const UnitFormInitial());
+  }
+}

--- a/lib/features/unit/presentation/bloc/unit_form/unit_form_event.dart
+++ b/lib/features/unit/presentation/bloc/unit_form/unit_form_event.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/unit/data/model/unit_request_dto.dart';
+
+abstract class UnitFormEvent extends Equatable {
+  const UnitFormEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class UnitFormInitialized extends UnitFormEvent {
+  const UnitFormInitialized(this.unitId);
+
+  final int? unitId;
+
+  @override
+  List<Object?> get props => [unitId];
+}
+
+class UnitFormSubmitted extends UnitFormEvent {
+  const UnitFormSubmitted({required this.dto, this.unitId});
+
+  final UnitRequestDto dto;
+  final int? unitId;
+
+  @override
+  List<Object?> get props => [dto, unitId];
+}
+
+class UnitFormReset extends UnitFormEvent {
+  const UnitFormReset();
+}

--- a/lib/features/unit/presentation/bloc/unit_form/unit_form_state.dart
+++ b/lib/features/unit/presentation/bloc/unit_form/unit_form_state.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+
+abstract class UnitFormState extends Equatable {
+  const UnitFormState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class UnitFormInitial extends UnitFormState {
+  const UnitFormInitial();
+}
+
+class UnitFormLoading extends UnitFormState {
+  const UnitFormLoading();
+}
+
+class UnitFormLoadSuccess extends UnitFormState {
+  const UnitFormLoadSuccess(this.unit);
+
+  final UnitEntity unit;
+
+  @override
+  List<Object?> get props => [unit];
+}
+
+class UnitFormSuccess extends UnitFormState {
+  const UnitFormSuccess(this.unit);
+
+  final UnitEntity unit;
+
+  @override
+  List<Object?> get props => [unit];
+}
+
+class UnitFormError extends UnitFormState {
+  const UnitFormError(this.message);
+
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/unit/presentation/bloc/unit_list/unit_list_bloc.dart
+++ b/lib/features/unit/presentation/bloc/unit_list/unit_list_bloc.dart
@@ -1,0 +1,151 @@
+import 'package:bloc/bloc.dart';
+import 'package:event_management/features/unit/data/model/page_response.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_event.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_state.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class UnitListBloc extends Bloc<UnitListEvent, UnitListState> {
+  UnitListBloc(this._unitRepository) : super(const UnitListInitial()) {
+    on<UnitListFetched>(_onFetched);
+    on<UnitListRefreshed>(_onRefreshed);
+    on<UnitListLoadMore>(_onLoadMore);
+    on<UnitListSearched>(_onSearched);
+    on<UnitListDeleted>(_onDeleted);
+  }
+
+  final UnitRepository _unitRepository;
+  String? _currentQuery;
+  int _currentPage = 0;
+
+  Future<void> _onFetched(
+    UnitListFetched event,
+    Emitter<UnitListState> emit,
+  ) async {
+    emit(const UnitListLoading());
+
+    try {
+      final pageResponse = await _unitRepository.listUnits(
+        query: event.query,
+        page: event.page,
+        size: event.size,
+      );
+      _currentQuery = event.query;
+      _currentPage = event.page;
+      emit(UnitListSuccess(pageResponse: pageResponse, query: event.query));
+    } catch (e) {
+      emit(UnitListError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onRefreshed(
+    UnitListRefreshed event,
+    Emitter<UnitListState> emit,
+  ) async {
+    if (state is UnitListSuccess) {
+      final currentState = state as UnitListSuccess;
+      emit(
+        UnitListSuccess(
+          pageResponse: currentState.pageResponse,
+          query: currentState.query,
+        ),
+      );
+    }
+
+    emit(const UnitListLoading());
+
+    try {
+      final pageResponse = await _unitRepository.listUnits(
+        query: event.query ?? _currentQuery,
+      );
+      _currentQuery = event.query ?? _currentQuery;
+      _currentPage = 0;
+      emit(
+        UnitListSuccess(
+          pageResponse: pageResponse,
+          query: event.query ?? _currentQuery,
+        ),
+      );
+    } catch (e) {
+      emit(UnitListError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onLoadMore(
+    UnitListLoadMore event,
+    Emitter<UnitListState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! UnitListSuccess) return;
+    if (!currentState.pageResponse.hasNext) return;
+
+    try {
+      final nextPage = _currentPage + 1;
+      final pageResponse = await _unitRepository.listUnits(
+        query: _currentQuery,
+        page: nextPage,
+      );
+
+      final updatedContent = [
+        ...currentState.pageResponse.content,
+        ...pageResponse.content,
+      ];
+
+      final updatedPageResponse = PageResponse<UnitEntity>(
+        content: updatedContent,
+        page: pageResponse.page,
+        size: pageResponse.size,
+        totalElements: pageResponse.totalElements,
+        totalPages: pageResponse.totalPages,
+        first: pageResponse.first,
+        last: pageResponse.last,
+        hasNext: pageResponse.hasNext,
+        hasPrevious: pageResponse.hasPrevious,
+        numberOfElements: pageResponse.numberOfElements,
+        empty: pageResponse.empty,
+      );
+
+      _currentPage = nextPage;
+      emit(
+        UnitListSuccess(
+          pageResponse: updatedPageResponse,
+          query: _currentQuery,
+        ),
+      );
+    } catch (e) {
+      emit(UnitListError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onSearched(
+    UnitListSearched event,
+    Emitter<UnitListState> emit,
+  ) async {
+    emit(const UnitListLoading());
+
+    try {
+      final pageResponse = await _unitRepository.listUnits(
+        query: event.query.isEmpty ? null : event.query,
+      );
+      _currentQuery = event.query.isEmpty ? null : event.query;
+      _currentPage = 0;
+      emit(UnitListSuccess(pageResponse: pageResponse, query: _currentQuery));
+    } catch (e) {
+      emit(UnitListError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onDeleted(
+    UnitListDeleted event,
+    Emitter<UnitListState> emit,
+  ) async {
+    try {
+      await _unitRepository.deleteUnit(event.unitId);
+      add(UnitListRefreshed(query: _currentQuery));
+    } catch (e) {
+      emit(UnitListError(e.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+}

--- a/lib/features/unit/presentation/bloc/unit_list/unit_list_event.dart
+++ b/lib/features/unit/presentation/bloc/unit_list/unit_list_event.dart
@@ -1,0 +1,50 @@
+import 'package:equatable/equatable.dart';
+
+abstract class UnitListEvent extends Equatable {
+  const UnitListEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class UnitListFetched extends UnitListEvent {
+  const UnitListFetched({this.query, this.page = 0, this.size = 20});
+
+  final String? query;
+  final int page;
+  final int size;
+
+  @override
+  List<Object?> get props => [query, page, size];
+}
+
+class UnitListRefreshed extends UnitListEvent {
+  const UnitListRefreshed({this.query});
+
+  final String? query;
+
+  @override
+  List<Object?> get props => [query];
+}
+
+class UnitListLoadMore extends UnitListEvent {
+  const UnitListLoadMore();
+}
+
+class UnitListSearched extends UnitListEvent {
+  const UnitListSearched(this.query);
+
+  final String query;
+
+  @override
+  List<Object?> get props => [query];
+}
+
+class UnitListDeleted extends UnitListEvent {
+  const UnitListDeleted(this.unitId);
+
+  final int unitId;
+
+  @override
+  List<Object?> get props => [unitId];
+}

--- a/lib/features/unit/presentation/bloc/unit_list/unit_list_state.dart
+++ b/lib/features/unit/presentation/bloc/unit_list/unit_list_state.dart
@@ -1,0 +1,49 @@
+import 'package:equatable/equatable.dart';
+import 'package:event_management/features/unit/data/model/page_response.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+
+abstract class UnitListState extends Equatable {
+  const UnitListState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class UnitListInitial extends UnitListState {
+  const UnitListInitial();
+}
+
+class UnitListLoading extends UnitListState {
+  const UnitListLoading();
+}
+
+class UnitListSuccess extends UnitListState {
+  const UnitListSuccess({required this.pageResponse, this.query});
+
+  final PageResponse<UnitEntity> pageResponse;
+  final String? query;
+
+  List<UnitEntity> get units => pageResponse.content;
+
+  UnitListSuccess copyWith({
+    PageResponse<UnitEntity>? pageResponse,
+    String? query,
+  }) {
+    return UnitListSuccess(
+      pageResponse: pageResponse ?? this.pageResponse,
+      query: query ?? this.query,
+    );
+  }
+
+  @override
+  List<Object?> get props => [pageResponse, query];
+}
+
+class UnitListError extends UnitListState {
+  const UnitListError(this.message);
+
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/unit/presentation/pages/unit_form_screen.dart
+++ b/lib/features/unit/presentation/pages/unit_form_screen.dart
@@ -1,0 +1,331 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/features/unit/data/model/unit_request_dto.dart';
+import 'package:event_management/features/unit/domain/entities/unit_type.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+import 'package:event_management/features/unit/domain/repository/unit_repository.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_bloc.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_event.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_form/unit_form_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class UnitFormScreen extends StatefulWidget {
+  const UnitFormScreen({this.unitId, super.key});
+
+  final int? unitId;
+
+  @override
+  State<UnitFormScreen> createState() => _UnitFormScreenState();
+}
+
+class _UnitFormScreenState extends State<UnitFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _unitNameController = TextEditingController();
+  UnitType _selectedUnitType = UnitType.department;
+  int? _selectedParentId;
+  List<UnitEntity> _allUnits = [];
+
+  @override
+  void initState() {
+    super.initState();
+    // Reset form state first
+    _resetForm();
+    // Reset BLoC state to ensure clean state
+    context.read<UnitFormBloc>().add(const UnitFormReset());
+    // Load all units first, then initialize form if editing
+    _loadAllUnits().then((_) {
+      if (widget.unitId != null && mounted) {
+        // Load unit data after all units are loaded
+        context.read<UnitFormBloc>().add(UnitFormInitialized(widget.unitId));
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(UnitFormScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Reset form if unitId changed
+    if (oldWidget.unitId != widget.unitId) {
+      _resetForm();
+      if (widget.unitId != null) {
+        context.read<UnitFormBloc>().add(const UnitFormReset());
+        context.read<UnitFormBloc>().add(UnitFormInitialized(widget.unitId));
+      } else {
+        context.read<UnitFormBloc>().add(const UnitFormReset());
+      }
+    }
+  }
+
+  void _resetForm() {
+    _unitNameController.clear();
+    _selectedUnitType = UnitType.department;
+    _selectedParentId = null;
+  }
+
+  @override
+  void dispose() {
+    _unitNameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadAllUnits() async {
+    try {
+      final unitRepository = di.sl<UnitRepository>();
+      final units = await unitRepository.getAllUnits();
+      if (mounted) {
+        setState(() {
+          _allUnits = units;
+        });
+      }
+    } catch (e) {
+      // Silently fail, parent units are optional
+    }
+  }
+
+  void _onSubmit() {
+    if (_formKey.currentState!.validate()) {
+      final dto = UnitRequestDto(
+        unitName: _unitNameController.text.trim(),
+        unitType: _selectedUnitType,
+        parentId: _selectedParentId,
+      );
+      context.read<UnitFormBloc>().add(
+        UnitFormSubmitted(dto: dto, unitId: widget.unitId),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.coolGray50,
+      appBar: AppBar(
+        title: Text(widget.unitId == null ? 'Thêm đơn vị' : 'Sửa đơn vị'),
+        backgroundColor: AppColors.vkuBlue,
+        foregroundColor: AppColors.white,
+      ),
+      body: BlocConsumer<UnitFormBloc, UnitFormState>(
+        listener: (context, state) {
+          if (state is UnitFormSuccess) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Lưu thành công!'),
+                backgroundColor: AppColors.green500,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+            Navigator.of(context).pop(true);
+          } else if (state is UnitFormError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: AppColors.red500,
+                behavior: SnackBarBehavior.floating,
+              ),
+            );
+          } else if (state is UnitFormLoadSuccess) {
+            // Always reset and set values when unit is loaded
+            // This ensures we show the correct unit data
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted && state.unit.id == widget.unitId) {
+                setState(() {
+                  _unitNameController.text = state.unit.unitName;
+                  _selectedUnitType = state.unit.unitType;
+                  // Set parentId - it will be validated in the dropdown builder
+                  _selectedParentId = state.unit.parentId;
+                });
+              }
+            });
+          }
+        },
+        builder: (context, state) {
+          final isLoading = state is UnitFormLoading;
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.spaceLG),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Card(
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      side: const BorderSide(color: AppColors.border),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSpacing.spaceLG),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            'Thông tin đơn vị',
+                            style: AppTextStyles.heading4,
+                          ),
+                          const SizedBox(height: AppSpacing.spaceLG),
+                          TextFormField(
+                            controller: _unitNameController,
+                            decoration: InputDecoration(
+                              labelText: 'Tên đơn vị *',
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              prefixIcon: const Icon(Icons.business_rounded),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'Vui lòng nhập tên đơn vị';
+                              }
+                              return null;
+                            },
+                            enabled: !isLoading,
+                          ),
+                          const SizedBox(height: AppSpacing.spaceMD),
+                          DropdownButtonFormField<UnitType>(
+                            initialValue: _selectedUnitType,
+                            decoration: InputDecoration(
+                              labelText: 'Loại đơn vị *',
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              prefixIcon: const Icon(Icons.category_rounded),
+                            ),
+                            items: UnitType.values.map((type) {
+                              return DropdownMenuItem(
+                                value: type,
+                                child: Text(type.label),
+                              );
+                            }).toList(),
+                            onChanged: isLoading
+                                ? null
+                                : (value) {
+                                    if (value != null) {
+                                      setState(() {
+                                        _selectedUnitType = value;
+                                      });
+                                    }
+                                  },
+                          ),
+                          const SizedBox(height: AppSpacing.spaceMD),
+                          Builder(
+                            builder: (context) {
+                              // Filter out current unit and get unique units
+                              final availableUnits = _allUnits
+                                  .where((u) => u.id != widget.unitId)
+                                  .toSet()
+                                  .toList();
+
+                              // Ensure selectedParentId exists in items
+                              final validParentId =
+                                  _selectedParentId != null &&
+                                      availableUnits.any(
+                                        (u) => u.id == _selectedParentId,
+                                      )
+                                  ? _selectedParentId
+                                  : null;
+
+                              // Update if needed
+                              if (validParentId != _selectedParentId) {
+                                WidgetsBinding.instance.addPostFrameCallback((
+                                  _,
+                                ) {
+                                  if (mounted) {
+                                    setState(() {
+                                      _selectedParentId = validParentId;
+                                    });
+                                  }
+                                });
+                              }
+
+                              return DropdownButtonFormField<int?>(
+                                initialValue: validParentId,
+                                decoration: InputDecoration(
+                                  labelText: 'Đơn vị cha (tùy chọn)',
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  prefixIcon: const Icon(
+                                    Icons.account_tree_rounded,
+                                  ),
+                                  isDense: true,
+                                  contentPadding: const EdgeInsets.symmetric(
+                                    horizontal: 16,
+                                    vertical: 12,
+                                  ),
+                                ),
+                                isExpanded: true,
+                                items: [
+                                  const DropdownMenuItem<int?>(
+                                    child: Text(
+                                      'Không có',
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                  ...availableUnits.map((unit) {
+                                    return DropdownMenuItem<int?>(
+                                      value: unit.id,
+                                      child: Text(
+                                        unit.unitName,
+                                        overflow: TextOverflow.ellipsis,
+                                        maxLines: 1,
+                                      ),
+                                    );
+                                  }),
+                                ],
+                                onChanged: isLoading
+                                    ? null
+                                    : (value) {
+                                        setState(() {
+                                          _selectedParentId = value;
+                                        });
+                                      },
+                              );
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.spaceLG),
+                  SizedBox(
+                    height: 50,
+                    child: ElevatedButton(
+                      onPressed: isLoading ? null : _onSubmit,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.vkuBlue,
+                        foregroundColor: AppColors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: isLoading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: AppColors.white,
+                              ),
+                            )
+                          : Text(
+                              widget.unitId == null ? 'Tạo mới' : 'Cập nhật',
+                              style: AppTextStyles.heading5.copyWith(
+                                color: AppColors.white,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/unit/presentation/pages/unit_list_screen.dart
+++ b/lib/features/unit/presentation/pages/unit_list_screen.dart
@@ -1,0 +1,399 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/router/app_router.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_bloc.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_event.dart';
+import 'package:event_management/features/unit/presentation/bloc/unit_list/unit_list_state.dart';
+import 'package:event_management/features/unit/presentation/widgets/unit_tree_item.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+class UnitListScreen extends StatefulWidget {
+  const UnitListScreen({this.showAppBar = true, super.key});
+
+  final bool showAppBar;
+
+  @override
+  State<UnitListScreen> createState() => _UnitListScreenState();
+}
+
+class _UnitListScreenState extends State<UnitListScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<UnitListBloc>().add(const UnitListFetched());
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_isBottom) {
+      context.read<UnitListBloc>().add(const UnitListLoadMore());
+    }
+  }
+
+  bool get _isBottom {
+    if (!_scrollController.hasClients) return false;
+    final maxScroll = _scrollController.position.maxScrollExtent;
+    final currentScroll = _scrollController.offset;
+    return currentScroll >= (maxScroll * 0.9);
+  }
+
+  void _onSearchChanged(String query) {
+    if (query.isEmpty) {
+      context.read<UnitListBloc>().add(const UnitListSearched(''));
+    } else {
+      context.read<UnitListBloc>().add(UnitListSearched(query));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final content = BlocConsumer<UnitListBloc, UnitListState>(
+      listener: (context, state) {
+        if (state is UnitListError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: AppColors.red500,
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        return CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            // App Bar (only if showAppBar is true)
+            if (widget.showAppBar)
+              SliverAppBar(
+                expandedHeight: 120,
+                pinned: true,
+                backgroundColor: AppColors.vkuBlue,
+                foregroundColor: AppColors.white,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: const Text('Quản Lý Đơn Vị'),
+                  titlePadding: const EdgeInsets.only(left: 16, bottom: 16),
+                  background: Container(
+                    decoration: BoxDecoration(
+                      gradient: AppColors.primaryGradient,
+                    ),
+                  ),
+                ),
+                actions: [
+                  IconButton(
+                    icon: const Icon(Icons.add_rounded),
+                    onPressed: () async {
+                      final result = await context.pushNamed<bool>(
+                        AppRoutes.unitForm,
+                      );
+                      // Refresh list if unit was created/updated
+                      if (result ?? false && mounted) {
+                        context.read<UnitListBloc>().add(
+                          const UnitListFetched(),
+                        );
+                      }
+                    },
+                    tooltip: 'Thêm đơn vị mới',
+                  ),
+                ],
+              ),
+
+            // Search Bar
+            SliverToBoxAdapter(
+              child: Container(
+                padding: const EdgeInsets.all(AppSpacing.spaceMD),
+                color: AppColors.white,
+                child: StatefulBuilder(
+                  builder: (context, setState) {
+                    return TextField(
+                      controller: _searchController,
+                      decoration: InputDecoration(
+                        hintText: 'Tìm kiếm đơn vị...',
+                        prefixIcon: const Icon(Icons.search_rounded),
+                        suffixIcon: _searchController.text.isNotEmpty
+                            ? IconButton(
+                                icon: const Icon(Icons.clear_rounded),
+                                onPressed: () {
+                                  _searchController.clear();
+                                  _onSearchChanged('');
+                                  setState(() {});
+                                },
+                              )
+                            : null,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: const BorderSide(color: AppColors.border),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: const BorderSide(color: AppColors.border),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: const BorderSide(
+                            color: AppColors.vkuBlue,
+                            width: 2,
+                          ),
+                        ),
+                        filled: true,
+                        fillColor: AppColors.coolGray50,
+                        isDense: true,
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                      ),
+                      onChanged: (value) {
+                        _onSearchChanged(value);
+                        setState(() {});
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+
+            // Content
+            if (state is UnitListLoading && state is! UnitListSuccess)
+              const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else if (state is UnitListError)
+              SliverFillRemaining(
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(
+                        Icons.error_outline_rounded,
+                        size: 64,
+                        color: AppColors.red500,
+                      ),
+                      const SizedBox(height: AppSpacing.spaceMD),
+                      Text(
+                        'Không thể tải danh sách đơn vị',
+                        style: AppTextStyles.heading4,
+                      ),
+                      const SizedBox(height: AppSpacing.spaceXS),
+                      Text(
+                        state.message,
+                        style: AppTextStyles.bodySmall,
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: AppSpacing.spaceLG),
+                      ElevatedButton(
+                        onPressed: () {
+                          context.read<UnitListBloc>().add(
+                            const UnitListFetched(),
+                          );
+                        },
+                        child: const Text('Thử lại'),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else if (state is UnitListSuccess)
+              state.units.isEmpty
+                  ? SliverFillRemaining(
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(
+                              Icons.business_rounded,
+                              size: 64,
+                              color: AppColors.coolGray500,
+                            ),
+                            const SizedBox(height: AppSpacing.spaceMD),
+                            Text(
+                              'Chưa có đơn vị nào',
+                              style: AppTextStyles.heading4,
+                            ),
+                            const SizedBox(height: AppSpacing.spaceXS),
+                            Text(
+                              'Nhấn nút + để thêm đơn vị mới',
+                              style: AppTextStyles.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  : SliverPadding(
+                      padding: const EdgeInsets.all(AppSpacing.spaceMD),
+                      sliver: SliverList(
+                        delegate: SliverChildBuilderDelegate(
+                          (context, index) {
+                            // Build tree structure
+                            final treeItems = _buildTreeStructure(state.units);
+
+                            if (index >= treeItems.length) {
+                              if (state.pageResponse.hasNext) {
+                                return const Padding(
+                                  padding: EdgeInsets.all(AppSpacing.spaceMD),
+                                  child: Center(
+                                    child: CircularProgressIndicator(),
+                                  ),
+                                );
+                              }
+                              return const SizedBox.shrink();
+                            }
+
+                            final treeItem = treeItems[index];
+                            return Padding(
+                              padding: EdgeInsets.only(
+                                bottom: index < treeItems.length - 1
+                                    ? AppSpacing.spaceMD
+                                    : 0,
+                              ),
+                              child: UnitTreeItem(
+                                unit: treeItem.unit,
+                                subUnits: treeItem.subUnits,
+                                allUnits: state.units,
+                                onTap: (unit) async {
+                                  final result = await context.pushNamed<bool>(
+                                    AppRoutes.unitFormEdit,
+                                    pathParameters: {'id': unit.id.toString()},
+                                  );
+                                  // Refresh list if unit was created/updated
+                                  if (result ?? false && mounted) {
+                                    context.read<UnitListBloc>().add(
+                                      const UnitListFetched(),
+                                    );
+                                  }
+                                },
+                                onDelete: (unit) {
+                                  _showDeleteDialog(context, unit);
+                                },
+                              ),
+                            );
+                          },
+                          childCount:
+                              _buildTreeStructure(state.units).length +
+                              (state.pageResponse.hasNext ? 1 : 0),
+                        ),
+                      ),
+                    )
+            else
+              const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+          ],
+        );
+      },
+    );
+
+    if (widget.showAppBar) {
+      return Scaffold(
+        backgroundColor: AppColors.coolGray50,
+        body: content,
+        floatingActionButton: FloatingActionButton(
+          onPressed: () async {
+            final result = await context.pushNamed<bool>(AppRoutes.unitForm);
+            if (result ?? false && mounted) {
+              context.read<UnitListBloc>().add(const UnitListFetched());
+            }
+          },
+          backgroundColor: AppColors.vkuBlue,
+          child: const Icon(Icons.add_rounded, color: AppColors.white),
+        ),
+      );
+    }
+
+    return Stack(
+      children: [
+        ColoredBox(color: AppColors.coolGray50, child: content),
+        // Floating Action Button when showAppBar is false
+        if (!widget.showAppBar)
+          Positioned(
+            bottom: 16,
+            right: 16,
+            child: FloatingActionButton(
+              onPressed: () async {
+                final result = await context.pushNamed<bool>(
+                  AppRoutes.unitForm,
+                );
+                if (result ?? false && mounted) {
+                  context.read<UnitListBloc>().add(const UnitListFetched());
+                }
+              },
+              backgroundColor: AppColors.vkuBlue,
+              child: const Icon(Icons.add_rounded, color: AppColors.white),
+            ),
+          ),
+      ],
+    );
+  }
+
+  List<_UnitTreeItem> _buildTreeStructure(List<UnitEntity> units) {
+    // Separate parent units and sub units
+    // A unit is a parent if parentId is null OR parentId equals its own id (self-reference)
+    final parentUnits = units
+        .where((u) => u.parentId == null || u.parentId == u.id)
+        .toList();
+    final subUnitsMap = <int, List<UnitEntity>>{};
+
+    for (final unit in units) {
+      // Only add to subUnitsMap if parentId exists, is not null, and is different from unit's id
+      if (unit.parentId != null && unit.parentId != unit.id) {
+        subUnitsMap.putIfAbsent(unit.parentId!, () => []).add(unit);
+      }
+    }
+
+    // Build tree items
+    final treeItems = <_UnitTreeItem>[];
+    for (final parent in parentUnits) {
+      final subUnits = subUnitsMap[parent.id] ?? [];
+      treeItems.add(_UnitTreeItem(unit: parent, subUnits: subUnits));
+    }
+
+    return treeItems;
+  }
+
+  void _showDeleteDialog(BuildContext context, UnitEntity unit) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Xác nhận xóa'),
+        content: Text('Bạn có chắc chắn muốn xóa đơn vị "${unit.unitName}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Hủy'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              // Use the original context that has access to UnitListBloc
+              context.read<UnitListBloc>().add(UnitListDeleted(unit.id));
+            },
+            style: TextButton.styleFrom(foregroundColor: AppColors.red500),
+            child: const Text('Xóa'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Helper class for tree structure
+class _UnitTreeItem {
+  const _UnitTreeItem({required this.unit, required this.subUnits});
+
+  final UnitEntity unit;
+  final List<UnitEntity> subUnits;
+}

--- a/lib/features/unit/presentation/widgets/unit_card.dart
+++ b/lib/features/unit/presentation/widgets/unit_card.dart
@@ -1,0 +1,122 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/features/unit/domain/entities/unit_type.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+import 'package:flutter/material.dart';
+
+class UnitCard extends StatelessWidget {
+  const UnitCard({
+    required this.unit,
+    required this.onTap,
+    this.onDelete,
+    super.key,
+  });
+
+  final UnitEntity unit;
+  final VoidCallback onTap;
+  final VoidCallback? onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: const BorderSide(color: AppColors.border),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.spaceMD),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: _getTypeColor(unit.unitType).withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  Icons.business_rounded,
+                  color: _getTypeColor(unit.unitType),
+                  size: 24,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.spaceMD),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      unit.unitName,
+                      style: AppTextStyles.heading5.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 2,
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: _getTypeColor(
+                              unit.unitType,
+                            ).withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            unit.unitType.label,
+                            style: AppTextStyles.caption.copyWith(
+                              color: _getTypeColor(unit.unitType),
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        if (unit.parentName != null) ...[
+                          const SizedBox(width: 8),
+                          Flexible(
+                            child: Text(
+                              '• ${unit.parentName}',
+                              style: AppTextStyles.bodySmall,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              if (onDelete != null)
+                IconButton(
+                  icon: const Icon(Icons.delete_outline_rounded),
+                  color: AppColors.red500,
+                  onPressed: onDelete,
+                  tooltip: 'Xóa',
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getTypeColor(UnitType unitType) {
+    switch (unitType) {
+      case UnitType.department:
+        return AppColors.vkuBlue;
+      case UnitType.student:
+        return AppColors.green500;
+      case UnitType.external:
+        return AppColors.amber600;
+    }
+  }
+}

--- a/lib/features/unit/presentation/widgets/unit_tree_item.dart
+++ b/lib/features/unit/presentation/widgets/unit_tree_item.dart
@@ -1,0 +1,146 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/features/unit/domain/entity/unit_entity.dart';
+import 'package:event_management/features/unit/presentation/widgets/unit_card.dart';
+import 'package:flutter/material.dart';
+
+class UnitTreeItem extends StatefulWidget {
+  const UnitTreeItem({
+    required this.unit,
+    required this.subUnits,
+    required this.onTap,
+    this.onDelete,
+    this.level = 0,
+    this.allUnits,
+    super.key,
+  });
+
+  final UnitEntity unit;
+  final List<UnitEntity> subUnits;
+  final void Function(UnitEntity unit) onTap;
+  final void Function(UnitEntity unit)? onDelete;
+  final int level;
+  final List<UnitEntity>? allUnits;
+
+  @override
+  State<UnitTreeItem> createState() => _UnitTreeItemState();
+}
+
+class _UnitTreeItemState extends State<UnitTreeItem>
+    with SingleTickerProviderStateMixin {
+  bool _isExpanded = true;
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+    _controller.value = 1.0; // Start expanded
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+      if (_isExpanded) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasChildren = widget.subUnits.isNotEmpty;
+    final indent = widget.level * 24.0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Parent Unit Card
+        Padding(
+          padding: EdgeInsets.only(left: indent),
+          child: Row(
+            children: [
+              // Expand/Collapse Button
+              if (hasChildren)
+                InkWell(
+                  onTap: _toggle,
+                  borderRadius: BorderRadius.circular(4),
+                  child: Container(
+                    width: 24,
+                    height: 24,
+                    alignment: Alignment.center,
+                    child: AnimatedRotation(
+                      turns: _isExpanded ? 0.25 : 0,
+                      duration: const Duration(milliseconds: 200),
+                      child: const Icon(
+                        Icons.chevron_right_rounded,
+                        size: 20,
+                        color: AppColors.coolGray500,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                const SizedBox(width: 24),
+              // Unit Card
+              Expanded(
+                child: UnitCard(
+                  unit: widget.unit,
+                  onTap: () => widget.onTap(widget.unit),
+                  onDelete: widget.onDelete != null
+                      ? () => widget.onDelete!(widget.unit)
+                      : null,
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Sub Units (with animation)
+        if (hasChildren)
+          SizeTransition(
+            sizeFactor: _animation,
+            child: Column(
+              children: [
+                const SizedBox(height: AppSpacing.spaceMD),
+                ...widget.subUnits.map((subUnit) {
+                  // Find sub-sub units if allUnits is provided
+                  // Only include units where parentId equals subUnit.id and is different from unit's own id
+                  final subSubUnits = widget.allUnits != null
+                      ? widget.allUnits!
+                            .where(
+                              (u) =>
+                                  u.parentId == subUnit.id &&
+                                  u.parentId != u.id,
+                            )
+                            .toList()
+                      : <UnitEntity>[];
+                  return UnitTreeItem(
+                    unit: subUnit,
+                    subUnits: subSubUnits,
+                    onTap: widget.onTap,
+                    onDelete: widget.onDelete,
+                    level: widget.level + 1,
+                    allUnits: widget.allUnits,
+                  );
+                }),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Sửa lỗi khi bấm edit sub unit thì load thông tin parent unit thay vì sub unit
- Sửa lỗi khi bấm xóa sub unit thì xóa parent unit thay vì sub unit
- Sửa lỗi thêm unit mới phải chuyển screen mới hiển thị (thêm auto refresh)
- Sửa lỗi overflow 24px ở event card trong màn admin dashboard
- Cập nhật UnitTreeItem để callback nhận đúng unit được chọn
- Thêm Expanded + SingleChildScrollView cho event card để tránh overflow