### PR TITLE
feat(EM-59): tích hợp trợ lý AI sáng tạo nội dung mô tả sự kiện

### DIFF
--- a/lib/features/event/event_create/presentation/pages/create_event_screen.dart
+++ b/lib/features/event/event_create/presentation/pages/create_event_screen.dart
@@ -3,9 +3,13 @@ import 'dart:io';
 import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
 import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
 import 'package:event_management/core/router/app_router.dart';
 import 'package:event_management/features/event/event_create/presentation/bloc/create_event_bloc.dart';
+import 'package:event_management/features/event/event_management/presentation/widgets/event_management/ai_description_generator_dialog.dart';
 import 'package:event_management/features/event/shared/data/models/create_event_dto.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_request.dart';
+import 'package:event_management/features/event/shared/domain/repositories/event_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -45,6 +49,94 @@ class _CreateEventViewState extends State<_CreateEventView> {
   XFile? _bannerImageFile;
 
   final ImagePicker _imagePicker = ImagePicker();
+  bool _isGeneratingDescription = false;
+
+  Future<void> _handleAiGenerate(GenerateDescriptionRequest request) async {
+    if (_nameController.text.trim().isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Vui lòng nhập tên sự kiện trước'),
+            backgroundColor: AppColors.red500,
+          ),
+        );
+      }
+      return;
+    }
+
+    if (_startDate == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Vui lòng chọn thời gian bắt đầu trước'),
+            backgroundColor: AppColors.red500,
+          ),
+        );
+      }
+      return;
+    }
+
+    setState(() {
+      _isGeneratingDescription = true;
+    });
+
+    try {
+      final repository = di.sl<EventRepository>();
+      final fullRequest = GenerateDescriptionRequest(
+        title: _nameController.text.trim(),
+        location: _locationController.text.trim().isEmpty
+            ? null
+            : _locationController.text.trim(),
+        startTime: _startDate!.toUtc().toIso8601String(),
+        endTime: _endDate?.toUtc().toIso8601String(),
+        additionalInfo: request.additionalInfo,
+        tone: request.tone,
+        length: request.length,
+        target: request.target,
+      );
+
+      final response = await repository.generateDescription(fullRequest);
+
+      if (mounted) {
+        setState(() {
+          // Use raw_text for simple TextFormField
+          _descriptionController.text = response.rawText;
+        });
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Đã tạo mô tả thành công!'),
+            backgroundColor: AppColors.green500,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Lỗi: $e'),
+            backgroundColor: AppColors.red500,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGeneratingDescription = false;
+        });
+      }
+    }
+  }
+
+  void _showAiDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (context) =>
+          AiDescriptionGeneratorDialog(onGenerate: _handleAiGenerate),
+    );
+  }
 
   @override
   void dispose() {
@@ -291,6 +383,59 @@ class _CreateEventViewState extends State<_CreateEventView> {
                         const SizedBox(height: AppSpacing.spaceMD),
 
                         // ===== Mô tả sự kiện =====
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                'Mô tả sự kiện',
+                                style: AppTextStyles.bodyMedium.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColors.coolGray700,
+                                ),
+                              ),
+                            ),
+                            OutlinedButton.icon(
+                              onPressed: _isGeneratingDescription
+                                  ? null
+                                  : _showAiDialog,
+                              icon: _isGeneratingDescription
+                                  ? const SizedBox(
+                                      width: 16,
+                                      height: 16,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        valueColor:
+                                            AlwaysStoppedAnimation<Color>(
+                                              AppColors.vkuBlue,
+                                            ),
+                                      ),
+                                    )
+                                  : const Icon(
+                                      Icons.auto_awesome_rounded,
+                                      size: 18,
+                                    ),
+                              label: Text(
+                                _isGeneratingDescription
+                                    ? 'Đang tạo...'
+                                    : 'Tạo với AI',
+                                style: AppTextStyles.bodySmall.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: AppColors.vkuBlue,
+                                side: const BorderSide(
+                                  color: AppColors.vkuBlue,
+                                ),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: AppSpacing.spaceMD,
+                                  vertical: AppSpacing.spaceXS,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: AppSpacing.spaceXS),
                         TextFormField(
                           controller: _descriptionController,
                           decoration: const InputDecoration(

--- a/lib/features/event/event_management/presentation/widgets/event_management/ai_description_generator_dialog.dart
+++ b/lib/features/event/event_management/presentation/widgets/event_management/ai_description_generator_dialog.dart
@@ -1,0 +1,471 @@
+import 'package:event_management/core/config/app_colors.dart';
+import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_request.dart';
+import 'package:flutter/material.dart';
+
+class AiDescriptionGeneratorDialog extends StatefulWidget {
+  const AiDescriptionGeneratorDialog({
+    required this.onGenerate,
+    this.existingContent,
+    super.key,
+  });
+
+  final Future<void> Function(GenerateDescriptionRequest request) onGenerate;
+  final String? existingContent;
+
+  @override
+  State<AiDescriptionGeneratorDialog> createState() =>
+      _AiDescriptionGeneratorDialogState();
+}
+
+class _AiDescriptionGeneratorDialogState
+    extends State<AiDescriptionGeneratorDialog> {
+  ContentTone _selectedTone = ContentTone.friendly;
+  ContentLength _selectedLength = ContentLength.medium;
+  ContentTarget _selectedTarget = ContentTarget.general;
+  final TextEditingController _additionalInfoController =
+      TextEditingController();
+  bool _isGenerating = false;
+  bool _useExistingContent = false;
+
+  String _getToneLabel(ContentTone tone) {
+    switch (tone) {
+      case ContentTone.professional:
+        return 'Chuyên nghiệp';
+      case ContentTone.friendly:
+        return 'Thân thiện';
+      case ContentTone.exciting:
+        return 'Hào hứng';
+      case ContentTone.formal:
+        return 'Trang trọng';
+      case ContentTone.casual:
+        return 'Thân mật';
+    }
+  }
+
+  String _getLengthLabel(ContentLength length) {
+    switch (length) {
+      case ContentLength.short:
+        return 'Ngắn (50-100 từ)';
+      case ContentLength.medium:
+        return 'Trung bình (100-200 từ)';
+      case ContentLength.long:
+        return 'Dài (200-300 từ)';
+    }
+  }
+
+  String _getTargetLabel(ContentTarget target) {
+    switch (target) {
+      case ContentTarget.website:
+        return 'Website';
+      case ContentTarget.facebook:
+        return 'Facebook';
+      case ContentTarget.email:
+        return 'Email marketing';
+      case ContentTarget.general:
+        return 'Tổng quát';
+    }
+  }
+
+  @override
+  void dispose() {
+    _additionalInfoController.dispose();
+    super.dispose();
+  }
+
+  String _stripHtmlTags(String html) {
+    // Simple HTML tag removal for preview
+    return html
+        .replaceAll(RegExp('<[^>]*>'), '')
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .trim();
+  }
+
+  Future<void> _handleGenerate() async {
+    setState(() {
+      _isGenerating = true;
+    });
+
+    try {
+      // Build additional info
+      String? additionalInfo = _additionalInfoController.text.trim();
+
+      // If user wants to use existing content, prepend it to additionalInfo
+      if (_useExistingContent &&
+          widget.existingContent != null &&
+          widget.existingContent!.trim().isNotEmpty) {
+        final existingText = _stripHtmlTags(widget.existingContent!);
+        if (existingText.isNotEmpty) {
+          final prefix = 'Dựa trên nội dung mô tả hiện tại:\n\n$existingText';
+          additionalInfo = additionalInfo.isEmpty
+              ? prefix
+              : '$prefix\n\nThông tin bổ sung:\n$additionalInfo';
+        }
+      }
+
+      final request = GenerateDescriptionRequest(
+        title: '', // Will be set by parent
+        tone: _selectedTone,
+        length: _selectedLength,
+        target: _selectedTarget,
+        startTime: '', // Will be set by parent
+        additionalInfo: additionalInfo.isEmpty ? null : additionalInfo,
+      );
+
+      await widget.onGenerate(request);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Lỗi: $e'), backgroundColor: AppColors.red500),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: 500,
+          maxHeight: MediaQuery.of(context).size.height * 0.9,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Header (fixed)
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.spaceLG),
+              child: Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: AppColors.vkuBlue.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Icon(
+                      Icons.auto_awesome_rounded,
+                      color: AppColors.vkuBlue,
+                      size: 24,
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.spaceMD),
+                  Expanded(
+                    child: Text(
+                      'Tạo mô tả với AI',
+                      style: AppTextStyles.heading4.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close_rounded),
+                    onPressed: _isGenerating
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            // Scrollable content
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.spaceLG,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Chọn cấu hình để AI tạo mô tả phù hợp:',
+                      style: AppTextStyles.bodyMedium.copyWith(
+                        color: AppColors.coolGray700,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceLG),
+                    // Giọng văn
+                    Text(
+                      'Giọng văn',
+                      style: AppTextStyles.heading5.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceXS),
+                    Wrap(
+                      spacing: AppSpacing.spaceXS,
+                      runSpacing: AppSpacing.spaceXS,
+                      children: ContentTone.values.map((tone) {
+                        final isSelected = _selectedTone == tone;
+                        return ChoiceChip(
+                          label: Text(_getToneLabel(tone)),
+                          selected: isSelected,
+                          onSelected: _isGenerating
+                              ? null
+                              : (selected) {
+                                  if (selected) {
+                                    setState(() {
+                                      _selectedTone = tone;
+                                    });
+                                  }
+                                },
+                          selectedColor: AppColors.vkuBlue.withOpacity(0.2),
+                          labelStyle: TextStyle(
+                            color: isSelected
+                                ? AppColors.vkuBlue
+                                : AppColors.coolGray700,
+                            fontWeight: isSelected
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
+                          side: BorderSide(
+                            color: isSelected
+                                ? AppColors.vkuBlue
+                                : AppColors.border,
+                            width: isSelected ? 2 : 1,
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceMD),
+                    // Độ dài
+                    Text(
+                      'Độ dài',
+                      style: AppTextStyles.heading5.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceXS),
+                    Wrap(
+                      spacing: AppSpacing.spaceXS,
+                      runSpacing: AppSpacing.spaceXS,
+                      children: ContentLength.values.map((length) {
+                        final isSelected = _selectedLength == length;
+                        return ChoiceChip(
+                          label: Text(_getLengthLabel(length)),
+                          selected: isSelected,
+                          onSelected: _isGenerating
+                              ? null
+                              : (selected) {
+                                  if (selected) {
+                                    setState(() {
+                                      _selectedLength = length;
+                                    });
+                                  }
+                                },
+                          selectedColor: AppColors.vkuBlue.withOpacity(0.2),
+                          labelStyle: TextStyle(
+                            color: isSelected
+                                ? AppColors.vkuBlue
+                                : AppColors.coolGray700,
+                            fontWeight: isSelected
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
+                          side: BorderSide(
+                            color: isSelected
+                                ? AppColors.vkuBlue
+                                : AppColors.border,
+                            width: isSelected ? 2 : 1,
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceMD),
+                    // Nền tảng đích
+                    Text(
+                      'Nền tảng đích',
+                      style: AppTextStyles.heading5.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceXS),
+                    Wrap(
+                      spacing: AppSpacing.spaceXS,
+                      runSpacing: AppSpacing.spaceXS,
+                      children: ContentTarget.values.map((target) {
+                        final isSelected = _selectedTarget == target;
+                        return ChoiceChip(
+                          label: Text(_getTargetLabel(target)),
+                          selected: isSelected,
+                          onSelected: _isGenerating
+                              ? null
+                              : (selected) {
+                                  if (selected) {
+                                    setState(() {
+                                      _selectedTarget = target;
+                                    });
+                                  }
+                                },
+                          selectedColor: AppColors.vkuBlue.withOpacity(0.2),
+                          labelStyle: TextStyle(
+                            color: isSelected
+                                ? AppColors.vkuBlue
+                                : AppColors.coolGray700,
+                            fontWeight: isSelected
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                          ),
+                          side: BorderSide(
+                            color: isSelected
+                                ? AppColors.vkuBlue
+                                : AppColors.border,
+                            width: isSelected ? 2 : 1,
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                    // Option to use existing content (if available)
+                    if (widget.existingContent != null &&
+                        widget.existingContent!.trim().isNotEmpty) ...[
+                      const SizedBox(height: AppSpacing.spaceMD),
+                      Container(
+                        padding: const EdgeInsets.all(AppSpacing.spaceMD),
+                        decoration: BoxDecoration(
+                          color: AppColors.vkuBlue.withOpacity(0.05),
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: AppColors.vkuBlue.withOpacity(0.2),
+                          ),
+                        ),
+                        child: Row(
+                          children: [
+                            Checkbox(
+                              value: _useExistingContent,
+                              onChanged: _isGenerating
+                                  ? null
+                                  : (value) {
+                                      setState(() {
+                                        _useExistingContent = value ?? false;
+                                      });
+                                    },
+                              activeColor: AppColors.vkuBlue,
+                            ),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Dựa trên nội dung hiện tại',
+                                    style: AppTextStyles.bodyMedium.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    'AI sẽ cải thiện và tạo lại dựa trên mô tả bạn đã có',
+                                    style: AppTextStyles.bodySmall.copyWith(
+                                      color: AppColors.coolGray500,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.spaceMD),
+                    // Thông tin bổ sung
+                    Text(
+                      'Thông tin bổ sung (tùy chọn)',
+                      style: AppTextStyles.heading5.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.spaceXS),
+                    TextField(
+                      controller: _additionalInfoController,
+                      enabled: !_isGenerating,
+                      maxLines: 3,
+                      decoration: InputDecoration(
+                        hintText:
+                            'Nhập thông tin bổ sung để AI tạo mô tả chính xác hơn...',
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: const BorderSide(color: AppColors.border),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: const BorderSide(color: AppColors.border),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: const BorderSide(
+                            color: AppColors.vkuBlue,
+                            width: 2,
+                          ),
+                        ),
+                        filled: true,
+                        fillColor: AppColors.coolGray50,
+                        contentPadding: const EdgeInsets.all(
+                          AppSpacing.spaceMD,
+                        ),
+                      ),
+                      style: AppTextStyles.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // Buttons (fixed at bottom)
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.spaceLG),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: _isGenerating
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                    child: const Text('Hủy'),
+                  ),
+                  const SizedBox(width: AppSpacing.spaceXS),
+                  ElevatedButton.icon(
+                    onPressed: _isGenerating ? null : _handleGenerate,
+                    icon: _isGenerating
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                AppColors.white,
+                              ),
+                            ),
+                          )
+                        : const Icon(Icons.auto_awesome_rounded, size: 18),
+                    label: Text(_isGenerating ? 'Đang tạo...' : 'Tạo ngay'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.vkuBlue,
+                      foregroundColor: AppColors.white,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.spaceLG,
+                        vertical: AppSpacing.spaceMD,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/event/event_management/presentation/widgets/event_management/edit_event_basic_info_section.dart
+++ b/lib/features/event/event_management/presentation/widgets/event_management/edit_event_basic_info_section.dart
@@ -1,15 +1,25 @@
+import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
+import 'package:event_management/core/config/app_text_styles.dart';
+import 'package:event_management/core/di/injection_container.dart' as di;
+import 'package:event_management/features/event/event_management/presentation/widgets/event_management/ai_description_generator_dialog.dart';
 import 'package:event_management/features/event/event_management/presentation/widgets/event_management/edit_event_html_editor.dart';
 import 'package:event_management/features/event/event_management/presentation/widgets/event_management/edit_event_modern_text_field.dart';
 import 'package:event_management/features/event/event_management/presentation/widgets/event_management/edit_event_section_header.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_request.dart';
+import 'package:event_management/features/event/shared/domain/repositories/event_repository.dart';
 import 'package:flutter/material.dart';
 
-class EditEventBasicInfoSection extends StatelessWidget {
+class EditEventBasicInfoSection extends StatefulWidget {
   const EditEventBasicInfoSection({
     required this.titleController,
     required this.descriptionHtml,
     required this.htmlEditorKey,
     required this.onDescriptionChanged,
+    this.startDate,
+    this.endDate,
+    this.location,
+    this.speakers,
     super.key,
   });
 
@@ -17,6 +27,189 @@ class EditEventBasicInfoSection extends StatelessWidget {
   final String descriptionHtml;
   final GlobalKey htmlEditorKey;
   final ValueChanged<String> onDescriptionChanged;
+  final DateTime? startDate;
+  final DateTime? endDate;
+  final String? location;
+  final List<String>? speakers;
+
+  @override
+  State<EditEventBasicInfoSection> createState() =>
+      _EditEventBasicInfoSectionState();
+}
+
+class _EditEventBasicInfoSectionState extends State<EditEventBasicInfoSection> {
+  bool _isGenerating = false;
+
+  Future<void> _handleAiGenerate(GenerateDescriptionRequest request) async {
+    if (widget.titleController.text.trim().isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Vui lòng nhập tên sự kiện trước'),
+            backgroundColor: AppColors.red500,
+          ),
+        );
+      }
+      return;
+    }
+
+    if (widget.startDate == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Vui lòng chọn thời gian bắt đầu trước'),
+            backgroundColor: AppColors.red500,
+          ),
+        );
+      }
+      return;
+    }
+
+    setState(() {
+      _isGenerating = true;
+    });
+
+    try {
+      final repository = di.sl<EventRepository>();
+      final fullRequest = GenerateDescriptionRequest(
+        title: widget.titleController.text.trim(),
+        location: widget.location,
+        startTime: widget.startDate!.toUtc().toIso8601String(),
+        endTime: widget.endDate?.toUtc().toIso8601String(),
+        speakers: widget.speakers,
+        additionalInfo: request.additionalInfo,
+        tone: request.tone,
+        length: request.length,
+        target: request.target,
+      );
+
+      final response = await repository.generateDescription(fullRequest);
+
+      if (mounted) {
+        // Check if there's existing content
+        final hasExistingContent = widget.descriptionHtml.trim().isNotEmpty;
+
+        // Only show confirmation if user didn't choose to use existing content
+        // (If they chose to use existing content, they already confirmed in the AI dialog)
+        final isUsingExistingContent =
+            request.additionalInfo != null &&
+            request.additionalInfo!.contains(
+              'Dựa trên nội dung mô tả hiện tại',
+            );
+
+        if (hasExistingContent && !isUsingExistingContent) {
+          // Show confirmation dialog before overwriting
+          final shouldOverwrite = await showDialog<bool>(
+            context: context,
+            builder: (context) => AlertDialog(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              title: Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: AppColors.amber100,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Icon(
+                      Icons.warning_rounded,
+                      color: AppColors.amber600,
+                      size: 24,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'Xác nhận ghi đè',
+                      style: AppTextStyles.heading4,
+                    ),
+                  ),
+                ],
+              ),
+              content: Text(
+                'Bạn đã có nội dung mô tả hiện tại. Nội dung mới từ AI sẽ thay thế nội dung cũ. Bạn có muốn tiếp tục?',
+                style: AppTextStyles.bodyMedium,
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: Text(
+                    'Hủy',
+                    style: AppTextStyles.heading5.copyWith(
+                      color: AppColors.coolGray700,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.vkuBlue,
+                    foregroundColor: AppColors.white,
+                  ),
+                  child: const Text('Ghi đè'),
+                ),
+              ],
+            ),
+          );
+
+          if (shouldOverwrite != true) {
+            // User cancelled, don't overwrite
+            return;
+          }
+        }
+
+        // Set the generated description to the HTML editor
+        final editorState = widget.htmlEditorKey.currentState;
+        if (editorState != null) {
+          final dynamic state = editorState;
+          if (state.setText != null) {
+            await state.setText(response.description);
+          }
+        }
+        widget.onDescriptionChanged(response.description);
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              hasExistingContent
+                  ? 'Đã cập nhật mô tả thành công!'
+                  : 'Đã tạo mô tả thành công!',
+            ),
+            backgroundColor: AppColors.green500,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Lỗi: $e'),
+            backgroundColor: AppColors.red500,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
+    }
+  }
+
+  void _showAiDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (context) => AiDescriptionGeneratorDialog(
+        onGenerate: _handleAiGenerate,
+        existingContent: widget.descriptionHtml,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +218,7 @@ class EditEventBasicInfoSection extends StatelessWidget {
       children: [
         const EditEventSectionHeader(title: 'Thông tin cơ bản'),
         EditEventModernTextField(
-          controller: titleController,
+          controller: widget.titleController,
           label: 'Tên sự kiện',
           icon: Icons.event_rounded,
           validator: (value) {
@@ -36,11 +229,49 @@ class EditEventBasicInfoSection extends StatelessWidget {
           },
         ),
         const SizedBox(height: AppSpacing.spaceMD),
-        const EditEventSectionHeader(title: 'Mô tả'),
+        Row(
+          children: [
+            const Expanded(child: EditEventSectionHeader(title: 'Mô tả')),
+            OutlinedButton.icon(
+              onPressed:
+                  (_isGenerating ||
+                      widget.titleController.text.trim().isEmpty ||
+                      widget.startDate == null)
+                  ? null
+                  : _showAiDialog,
+              icon: _isGenerating
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          AppColors.vkuBlue,
+                        ),
+                      ),
+                    )
+                  : const Icon(Icons.auto_awesome_rounded, size: 18),
+              label: Text(
+                _isGenerating ? 'Đang tạo...' : 'Tạo với AI',
+                style: AppTextStyles.bodySmall.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.vkuBlue,
+                side: const BorderSide(color: AppColors.vkuBlue),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.spaceMD,
+                  vertical: AppSpacing.spaceXS,
+                ),
+              ),
+            ),
+          ],
+        ),
         EditEventHtmlEditor(
-          key: htmlEditorKey,
-          initialValue: descriptionHtml,
-          onChanged: onDescriptionChanged,
+          key: widget.htmlEditorKey,
+          initialValue: widget.descriptionHtml,
+          onChanged: widget.onDescriptionChanged,
           validator: (value) {
             if (value == null || value.trim().isEmpty) {
               return 'Vui lòng nhập mô tả';

--- a/lib/features/event/event_management/presentation/widgets/event_management/edit_event_html_editor.dart
+++ b/lib/features/event/event_management/presentation/widgets/event_management/edit_event_html_editor.dart
@@ -22,11 +22,30 @@ class EditEventHtmlEditor extends StatefulWidget {
 class _EditEventHtmlEditorState extends State<EditEventHtmlEditor> {
   late HtmlEditorController _controller;
   String? _errorText;
+  String? _lastSetValue;
 
   @override
   void initState() {
     super.initState();
     _controller = HtmlEditorController();
+    _lastSetValue = widget.initialValue;
+  }
+
+  @override
+  void didUpdateWidget(EditEventHtmlEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Update editor if initialValue changed from outside
+    if (widget.initialValue != _lastSetValue) {
+      _lastSetValue = widget.initialValue;
+      _controller.setText(widget.initialValue);
+    }
+  }
+
+  /// Set text programmatically (for AI generation)
+  Future<void> setText(String text) async {
+    _lastSetValue = text;
+    _controller.setText(text);
+    _notifyChanged();
   }
 
   @override

--- a/lib/features/event/event_management/presentation/widgets/event_management/edit_event_tab.dart
+++ b/lib/features/event/event_management/presentation/widgets/event_management/edit_event_tab.dart
@@ -4,8 +4,6 @@ import 'package:event_management/core/config/app_colors.dart';
 import 'package:event_management/core/config/app_spacing.dart';
 import 'package:event_management/core/config/app_text_styles.dart';
 import 'package:event_management/core/di/injection_container.dart';
-import 'package:event_management/features/event/shared/data/models/event_detail_response.dart';
-import 'package:event_management/features/event/shared/domain/repositories/event_repository.dart';
 import 'package:event_management/features/event/event_detail/presentation/bloc/event_detail_bloc.dart';
 import 'package:event_management/features/event/event_detail/presentation/bloc/event_detail_event.dart';
 import 'package:event_management/features/event/event_detail/presentation/bloc/event_detail_state.dart';
@@ -16,6 +14,8 @@ import 'package:event_management/features/event/event_management/presentation/wi
 import 'package:event_management/features/event/event_management/presentation/widgets/event_management/edit_event_form_controller.dart';
 import 'package:event_management/features/event/event_management/presentation/widgets/event_management/edit_event_image_picker.dart';
 import 'package:event_management/features/event/event_management/presentation/widgets/event_management/edit_event_location_section.dart';
+import 'package:event_management/features/event/shared/data/models/event_detail_response.dart';
+import 'package:event_management/features/event/shared/domain/repositories/event_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -325,6 +325,9 @@ class _EditEventTabState extends State<EditEventTab> {
                     titleController: _formController.titleController,
                     descriptionHtml: _formController.descriptionHtml,
                     htmlEditorKey: _htmlEditorKey,
+                    startDate: _formController.startDate,
+                    endDate: _formController.endDate,
+                    location: _formController.locationController.text.trim(),
                     onDescriptionChanged: (value) {
                       setState(() {
                         _formController.descriptionHtml = value;

--- a/lib/features/event/shared/data/datasources/event_api_client.dart
+++ b/lib/features/event/shared/data/datasources/event_api_client.dart
@@ -6,6 +6,8 @@ import 'package:event_management/features/event/shared/data/models/event_detail_
 import 'package:event_management/features/event/shared/data/models/event_dto.dart';
 import 'package:event_management/features/event/shared/data/models/event_manager_dto.dart';
 import 'package:event_management/features/event/shared/data/models/event_page_with_counters_response_dto.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_request.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_response.dart';
 import 'package:event_management/features/event/shared/data/models/image_upload_response.dart';
 import 'package:event_management/features/event/shared/data/models/import_job_response.dart';
 import 'package:event_management/features/event/shared/data/models/import_participants_response.dart';
@@ -90,4 +92,9 @@ abstract class EventApiClient {
   Future<List<EventManagerDto>> getEventManagersByEventId({
     @Query('eventId') required int eventId,
   });
+
+  @POST('/events/generate-description')
+  Future<GenerateDescriptionResponse> generateDescription(
+    @Body() GenerateDescriptionRequest request,
+  );
 }

--- a/lib/features/event/shared/data/datasources/event_api_client.g.dart
+++ b/lib/features/event/shared/data/datasources/event_api_client.g.dart
@@ -456,6 +456,36 @@ class _EventApiClient implements EventApiClient {
     return _value;
   }
 
+  @override
+  Future<GenerateDescriptionResponse> generateDescription(
+    GenerateDescriptionRequest request,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(request.toJson());
+    final _options = _setStreamType<GenerateDescriptionResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/events/generate-description',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GenerateDescriptionResponse _value;
+    try {
+      _value = GenerateDescriptionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/event/shared/data/models/generate_description_request.dart
+++ b/lib/features/event/shared/data/models/generate_description_request.dart
@@ -1,0 +1,69 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'generate_description_request.g.dart';
+
+@JsonSerializable()
+class GenerateDescriptionRequest {
+  const GenerateDescriptionRequest({
+    required this.title,
+    this.location,
+    required this.startTime,
+    this.endTime,
+    this.speakers,
+    this.additionalInfo,
+    required this.tone,
+    required this.length,
+    required this.target,
+  });
+
+  final String title;
+  final String? location;
+  @JsonKey(name: 'start_time')
+  final String startTime;
+  @JsonKey(name: 'end_time')
+  final String? endTime;
+  final List<String>? speakers;
+  @JsonKey(name: 'additional_info')
+  final String? additionalInfo;
+  final ContentTone tone;
+  final ContentLength length;
+  final ContentTarget target;
+
+  factory GenerateDescriptionRequest.fromJson(Map<String, dynamic> json) =>
+      _$GenerateDescriptionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$GenerateDescriptionRequestToJson(this);
+}
+
+enum ContentTone {
+  @JsonValue('PROFESSIONAL')
+  professional,
+  @JsonValue('FRIENDLY')
+  friendly,
+  @JsonValue('EXCITING')
+  exciting,
+  @JsonValue('FORMAL')
+  formal,
+  @JsonValue('CASUAL')
+  casual,
+}
+
+enum ContentLength {
+  @JsonValue('SHORT')
+  short,
+  @JsonValue('MEDIUM')
+  medium,
+  @JsonValue('LONG')
+  long,
+}
+
+enum ContentTarget {
+  @JsonValue('WEBSITE')
+  website,
+  @JsonValue('FACEBOOK')
+  facebook,
+  @JsonValue('EMAIL')
+  email,
+  @JsonValue('GENERAL')
+  general,
+}

--- a/lib/features/event/shared/data/models/generate_description_request.g.dart
+++ b/lib/features/event/shared/data/models/generate_description_request.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generate_description_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GenerateDescriptionRequest _$GenerateDescriptionRequestFromJson(
+  Map<String, dynamic> json,
+) => GenerateDescriptionRequest(
+  title: json['title'] as String,
+  location: json['location'] as String?,
+  startTime: json['start_time'] as String,
+  endTime: json['end_time'] as String?,
+  speakers: (json['speakers'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+  additionalInfo: json['additional_info'] as String?,
+  tone: $enumDecode(_$ContentToneEnumMap, json['tone']),
+  length: $enumDecode(_$ContentLengthEnumMap, json['length']),
+  target: $enumDecode(_$ContentTargetEnumMap, json['target']),
+);
+
+Map<String, dynamic> _$GenerateDescriptionRequestToJson(
+  GenerateDescriptionRequest instance,
+) => <String, dynamic>{
+  'title': instance.title,
+  'location': instance.location,
+  'start_time': instance.startTime,
+  'end_time': instance.endTime,
+  'speakers': instance.speakers,
+  'additional_info': instance.additionalInfo,
+  'tone': _$ContentToneEnumMap[instance.tone]!,
+  'length': _$ContentLengthEnumMap[instance.length]!,
+  'target': _$ContentTargetEnumMap[instance.target]!,
+};
+
+const _$ContentToneEnumMap = {
+  ContentTone.professional: 'PROFESSIONAL',
+  ContentTone.friendly: 'FRIENDLY',
+  ContentTone.exciting: 'EXCITING',
+  ContentTone.formal: 'FORMAL',
+  ContentTone.casual: 'CASUAL',
+};
+
+const _$ContentLengthEnumMap = {
+  ContentLength.short: 'SHORT',
+  ContentLength.medium: 'MEDIUM',
+  ContentLength.long: 'LONG',
+};
+
+const _$ContentTargetEnumMap = {
+  ContentTarget.website: 'WEBSITE',
+  ContentTarget.facebook: 'FACEBOOK',
+  ContentTarget.email: 'EMAIL',
+  ContentTarget.general: 'GENERAL',
+};

--- a/lib/features/event/shared/data/models/generate_description_response.dart
+++ b/lib/features/event/shared/data/models/generate_description_response.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'generate_description_response.g.dart';
+
+@JsonSerializable()
+class GenerateDescriptionResponse {
+  const GenerateDescriptionResponse({
+    required this.description,
+    required this.rawText,
+  });
+
+  factory GenerateDescriptionResponse.fromJson(Map<String, dynamic> json) =>
+      _$GenerateDescriptionResponseFromJson(json);
+
+  final String description;
+  @JsonKey(name: 'raw_text')
+  final String rawText;
+
+  Map<String, dynamic> toJson() => _$GenerateDescriptionResponseToJson(this);
+}

--- a/lib/features/event/shared/data/models/generate_description_response.g.dart
+++ b/lib/features/event/shared/data/models/generate_description_response.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generate_description_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GenerateDescriptionResponse _$GenerateDescriptionResponseFromJson(
+  Map<String, dynamic> json,
+) => GenerateDescriptionResponse(
+  description: json['description'] as String,
+  rawText: json['raw_text'] as String,
+);
+
+Map<String, dynamic> _$GenerateDescriptionResponseToJson(
+  GenerateDescriptionResponse instance,
+) => <String, dynamic>{
+  'description': instance.description,
+  'raw_text': instance.rawText,
+};

--- a/lib/features/event/shared/data/repositories/event_repository_impl.dart
+++ b/lib/features/event/shared/data/repositories/event_repository_impl.dart
@@ -10,6 +10,8 @@ import 'package:event_management/features/event/shared/data/models/event_detail_
 import 'package:event_management/features/event/shared/data/models/event_dto.dart';
 import 'package:event_management/features/event/shared/data/models/event_manager_info.dart';
 import 'package:event_management/features/event/shared/data/models/event_status.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_request.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_response.dart';
 import 'package:event_management/features/event/shared/data/models/import_job_response.dart';
 import 'package:event_management/features/event/shared/data/models/import_participants_response.dart';
 import 'package:event_management/features/event/shared/domain/repositories/event_repository.dart';
@@ -503,6 +505,24 @@ class EventRepositoryImpl implements EventRepository {
         throw Exception(
           errorMessage ?? 'Không thể tải danh sách quản lý sự kiện.',
         );
+      }
+      throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
+    } catch (e) {
+      if (e is Exception) rethrow;
+      throw Exception('Đã xảy ra lỗi không xác định: $e');
+    }
+  }
+
+  @override
+  Future<GenerateDescriptionResponse> generateDescription(
+    GenerateDescriptionRequest request,
+  ) async {
+    try {
+      return await _eventApiClient.generateDescription(request);
+    } on DioException catch (e) {
+      if (e.response?.data != null && e.response!.data is Map) {
+        final errorMessage = e.response!.data['message'] as String?;
+        throw Exception(errorMessage ?? 'Không thể tạo mô tả với AI.');
       }
       throw Exception('Không thể kết nối đến máy chủ. Vui lòng thử lại.');
     } catch (e) {

--- a/lib/features/event/shared/domain/repositories/event_repository.dart
+++ b/lib/features/event/shared/domain/repositories/event_repository.dart
@@ -8,6 +8,8 @@ import 'package:event_management/features/event/shared/data/models/event_detail_
 import 'package:event_management/features/event/shared/data/models/event_dto.dart';
 import 'package:event_management/features/event/shared/data/models/event_manager_info.dart';
 import 'package:event_management/features/event/shared/data/models/event_status.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_request.dart';
+import 'package:event_management/features/event/shared/data/models/generate_description_response.dart';
 import 'package:event_management/features/event/shared/data/models/import_job_response.dart';
 import 'package:event_management/features/event/shared/data/models/import_participants_response.dart';
 import 'package:image_picker/image_picker.dart';
@@ -63,6 +65,10 @@ abstract class EventRepository {
   Future<Uint8List> getQrCheck(int eventId);
 
   Future<List<EventManagerInfo>> getEventManagers(int eventId);
+
+  Future<GenerateDescriptionResponse> generateDescription(
+    GenerateDescriptionRequest request,
+  );
 }
 
 class EventListResult {


### PR DESCRIPTION
- Thêm API endpoint generate-description để tạo mô tả sự kiện bằng AI
- Tạo dialog AI Description Generator với các tùy chọn:
  + Giọng văn (Chuyên nghiệp, Thân thiện, Hào hứng, Trang trọng, Thân mật)
  + Độ dài (Ngắn, Trung bình, Dài)
  + Nền tảng đích (Website, Facebook, Email, Tổng quát)
  + Thông tin bổ sung (tùy chọn)
  + Tùy chọn dựa trên nội dung hiện tại để cải thiện
- Tích hợp vào trang tạo sự kiện (CreateEventScreen)
- Tích hợp vào trang sửa sự kiện (EditEventTab)
- Xử lý validation: yêu cầu tên sự kiện và thời gian bắt đầu
- Xử lý khi đã có nội dung cũ: hiển thị dialog xác nhận ghi đè
- Sửa lỗi overflow trong dialog bằng cách thêm scrollable content
- Cập nhật repository và API client để hỗ trợ generate description
- Thêm models: GenerateDescriptionRequest, GenerateDescriptionResponse