### PR TITLE
feat(EM-62): cải thiện UX chi tiết sự kiện cho người tham dự

### DIFF
--- a/lib/features/event/event_detail/presentation/pages/event_detail_screen.dart
+++ b/lib/features/event/event_detail/presentation/pages/event_detail_screen.dart
@@ -402,6 +402,38 @@ class _EventDetailContentState extends State<_EventDetailContent> {
                       EventDetailTitle(title: widget.eventDetail.title),
                       const SizedBox(height: AppSpacing.spaceXM),
                       EventDetailStatusChip(status: widget.eventDetail.status),
+                      if (widget.eventDetail.isUserCheckedIn ?? false)
+                        Padding(
+                          padding: const EdgeInsets.only(
+                            top: AppSpacing.spaceXS,
+                          ),
+                          child: Row(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.all(
+                                  AppSpacing.spaceXS,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: AppColors.green50,
+                                  borderRadius: BorderRadius.circular(999),
+                                ),
+                                child: const Icon(
+                                  Icons.verified_rounded,
+                                  color: AppColors.green500,
+                                  size: 16,
+                                ),
+                              ),
+                              const SizedBox(width: AppSpacing.spaceXS),
+                              Text(
+                                'Bạn đã check-in sự kiện này',
+                                style: AppTextStyles.bodySmall.copyWith(
+                                  color: AppColors.green800,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                     ],
                   ),
                 ),

--- a/lib/features/event/shared/data/models/event_detail_response.dart
+++ b/lib/features/event/shared/data/models/event_detail_response.dart
@@ -26,6 +26,7 @@ class EventDetailResponse extends Equatable {
     this.qrJoinToken,
     this.updatedAt,
     this.isUserRegistered,
+    this.isUserCheckedIn,
     this.participants = const [],
     this.manager = const [],
     this.secretaries = const [],
@@ -74,6 +75,9 @@ class EventDetailResponse extends Equatable {
   @JsonKey(name: 'is_user_registered')
   final bool? isUserRegistered;
 
+  @JsonKey(name: 'is_user_checked_in')
+  final bool? isUserCheckedIn;
+
   final List<ParticipantInfo> participants;
 
   final List<ManagerInfo> manager;
@@ -97,6 +101,7 @@ class EventDetailResponse extends Equatable {
     createdAt,
     updatedAt,
     isUserRegistered,
+    isUserCheckedIn,
     participants,
     manager,
     secretaries,

--- a/lib/features/event/shared/data/models/event_detail_response.g.dart
+++ b/lib/features/event/shared/data/models/event_detail_response.g.dart
@@ -31,6 +31,7 @@ EventDetailResponse _$EventDetailResponseFromJson(Map<String, dynamic> json) =>
         (json['updated_at'] as num?)?.toDouble(),
       ),
       isUserRegistered: json['is_user_registered'] as bool?,
+      isUserCheckedIn: json['is_user_checked_in'] as bool?,
       participants:
           (json['participants'] as List<dynamic>?)
               ?.map((e) => ParticipantInfo.fromJson(e as Map<String, dynamic>))


### PR DESCRIPTION
- Ánh xạ field is_user_checked_in từ API vào EventDetailResponse
- Hiển thị badge "Bạn đã check-in sự kiện này" ngay dưới tiêu đề/status
- Không thay đổi luồng join/unjoin hiện tại, chỉ bổ sung thông tin trực quan cho người dùng